### PR TITLE
feat: enable bootstrap to handle only one class

### DIFF
--- a/src/psycop/model_evaluation/binary/utils.py
+++ b/src/psycop/model_evaluation/binary/utils.py
@@ -11,7 +11,7 @@ def calc_performance(
     df: pd.DataFrame,
     metric: Callable,
     confidence_interval: Optional[float] = None,
-    n_bootstraps: int = 1000,
+    n_bootstraps: int = 100,
     **kwargs: Any,
 ) -> pd.Series:
     """Calculates performance metrics of a df with 'y' and 'input_to_fn' columns.
@@ -59,7 +59,11 @@ def calc_performance(
         ) -> float:
             # bootstrap function requires the metric function to
             # be able to take additional arguments (notably the length of the array)
-            return metric(true, pred)
+            try:
+                return metric(true, pred)
+            except ValueError as e:
+                 print(repr(e))
+                 return np.nan
 
         boot = bootstrap(
             (df["y"], df["y_hat"]),

--- a/src/psycop/model_evaluation/binary/utils.py
+++ b/src/psycop/model_evaluation/binary/utils.py
@@ -62,8 +62,8 @@ def calc_performance(
             try:
                 return metric(true, pred)
             except ValueError as e:
-                 print(repr(e))
-                 return np.nan
+                print(repr(e))
+                return np.nan
 
         boot = bootstrap(
             (df["y"], df["y_hat"]),


### PR DESCRIPTION
2 edits:

* `n_bootstraps`: Required for plots to take less than 10 minutes per plot. Also, acceptable according to:
> "An Introduction to the Bootstrap" (1994) by Efron and Tibshirani, they report that you can get a decent estimate with B=25, and B=200 you approach a similar coefficient of variation as infinity. They provide a table of the coefficients of variation for various B (p. 52-53, both pages are available on google books).

* Added a try/except to `metric_wrapper`
For e.g. `roc_auc_by_hour_of_day`, some of the resampled datasets included only one class for true values (i.e. only negatives), and as such, `roc_auc` was undefined. In those cases, return `np.nan`. Makes for some somewhat ugly figures:
![auc_by_hour_of_day](https://user-images.githubusercontent.com/8526086/237030716-efbb972a-d239-4903-a6ed-59dfa7e1bfe9.png)

But I don't see how else to fix it. Any suggestions, @KennethEnevoldsen? :-)