### PR TITLE
feat: add markdown handler to common

### DIFF
--- a/src/psycop/common/model_evaluation/markdown/md_objects.py
+++ b/src/psycop/common/model_evaluation/markdown/md_objects.py
@@ -30,7 +30,7 @@ class MarkdownFigure(MarkdownArtifact):
         title: str,
         title_prefix: str = "Figure",
         check_filepath_exists: bool = True,
-        relative_to: Optional[Path] = None,
+        relative_to_path: Optional[Path] = None,
     ):
         super().__init__(
             title=title,
@@ -38,13 +38,14 @@ class MarkdownFigure(MarkdownArtifact):
             description=description,
             check_filepath_exists=check_filepath_exists,
         )
+
         self.title_prefix = title_prefix
 
-        if relative_to is not None:
-            self.file_path = self.file_path.relative_to(relative_to)
+        if relative_to_path is not None:
+            self.file_path = self.file_path.relative_to(relative_to_path)
 
     def get_markdown(self) -> str:
-        return f"""{self.title}
+        return f"""{self.title_prefix} {self.title}
 
 ![]({self.file_path.as_posix()})
 
@@ -88,7 +89,7 @@ class MarkdownTable(MarkdownArtifact):
         return df.to_markdown(index=False)
 
     def get_markdown(self) -> str:
-        return f"""{self.title}
+        return f"""{self.title_prefix} {self.title}
 
 {self.get_markdown_table()}
 
@@ -99,7 +100,9 @@ class MarkdownTable(MarkdownArtifact):
 def create_supplementary_from_markdown_artifacts(
     artifacts: Sequence[MarkdownArtifact],
     first_table_index: int = 1,
+    table_title_prefix: str = "eTable",
     first_figure_index: int = 1,
+    figure_title_prefix: str = "eFigure",
 ) -> str:
     tables = tuple(a for a in artifacts if isinstance(a, MarkdownTable))
     figures = tuple(a for a in artifacts if isinstance(a, MarkdownFigure))
@@ -110,10 +113,10 @@ def create_supplementary_from_markdown_artifacts(
 
     for artifacts in figures, tables:
         if isinstance(artifacts[0], MarkdownTable):
-            title_prefix = "eTable"
+            title_prefix = table_title_prefix
             index = first_table_index
         elif isinstance(artifacts[0], MarkdownFigure):
-            title_prefix = "eFigure"
+            title_prefix = figure_title_prefix
             index = first_figure_index
         else:
             raise ValueError(f"Unknown artifact type {type(artifacts[0])}")

--- a/src/psycop/common/model_evaluation/markdown/test_md_objects.py
+++ b/src/psycop/common/model_evaluation/markdown/test_md_objects.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from psycop.common.test_utils.str_to_df import str_to_df
 from psycop.common.model_evaluation.markdown.md_objects import (
     MarkdownFigure,
     MarkdownTable,
     create_supplementary_from_markdown_artifacts,
 )
+from psycop.common.test_utils.str_to_df import str_to_df
 
 
 class TestMarkdownFigure:

--- a/src/psycop/common/model_evaluation/markdown/test_md_objects.py
+++ b/src/psycop/common/model_evaluation/markdown/test_md_objects.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 from psycop.common.test_utils.str_to_df import str_to_df
-from psycop.projects.t2d.paper_outputs.aggregate_eval.md_objects import (
+from psycop.common.model_evaluation.markdown.md_objects import (
     MarkdownFigure,
     MarkdownTable,
     create_supplementary_from_markdown_artifacts,

--- a/src/psycop/common/model_evaluation/markdown/test_md_objects.py
+++ b/src/psycop/common/model_evaluation/markdown/test_md_objects.py
@@ -117,8 +117,13 @@ class TestCreateSupplementaryFromMarkdownArtifacts:
         md = create_supplementary_from_markdown_artifacts(
             artifacts=artifacts,
             first_table_index=3,
+            table_title_prefix="eTable",
             first_figure_index=1,
+            figure_title_prefix="eFigure",
         )
+
+        assert "eTable 3" in md
+        assert "eFigure 1" in md
 
         with (tmp_path / "test.md").open("w") as f:
             f.write(md)

--- a/src/psycop/common/model_evaluation/markdown/test_md_objects.py
+++ b/src/psycop/common/model_evaluation/markdown/test_md_objects.py
@@ -83,6 +83,9 @@ class TestCreateSupplementaryFromMarkdownArtifacts:
 
     def test_can_output_markdown(self, tmp_path: Path):
         self.table_csv.to_csv(tmp_path / "table.csv", index=False)
+        filepath = tmp_path / "test.md"
+        with filepath.open("w") as f:
+            f.write("Testing 123")
 
         artifacts = [
             MarkdownTable(
@@ -93,9 +96,9 @@ class TestCreateSupplementaryFromMarkdownArtifacts:
             ),
             MarkdownFigure(
                 title="Figure_title",
-                file_path=Path("path/to/file"),
+                file_path=filepath,
                 description="Figure description",
-                check_filepath_exists=False,
+                relative_to_path=tmp_path,
             ),
             MarkdownTable(
                 title="Table_title",

--- a/src/psycop/projects/t2d/paper_outputs/aggregate_eval/single_pipeline_full_eval.py
+++ b/src/psycop/projects/t2d/paper_outputs/aggregate_eval/single_pipeline_full_eval.py
@@ -1,4 +1,4 @@
-from psycop.projects.t2d.paper_outputs.aggregate_eval.md_objects import (
+from psycop.common.model_evaluation.markdown.md_objects import (
     MarkdownArtifact,
     MarkdownFigure,
     MarkdownTable,
@@ -31,14 +31,14 @@ def _t2d_create_markdown_artifacts(pipeline: PipelineRun) -> list[MarkdownArtifa
             file_path=pipeline.paper_outputs.paths.figures
             / pipeline.paper_outputs.artifact_names.main_performance_figure,
             description="**A**: Receiver operating characteristics (ROC) curve. **B**: Confusion matrix. PPV: Positive predictive value. NPV: Negative predictive value. **C**: Sensitivity by months from prediction time to event, stratified by desired predicted positive rate (PPR). Note that the numbers do not match those in Table 1, since all prediction times with insufficient lookahead distance have been dropped. **D**: Distribution of years from the first positive prediction to the patient fulfilling T2D-criteria at a 3% predicted positive rate (PPR).",
-            relative_to=relative_to,
+            relative_to_path=relative_to,
         ),
         MarkdownFigure(
             title=f"Robustness of {pipeline.model_type} at a {pos_rate_percent} predicted positive rate with {lookahead_years} years of lookahead",
             file_path=pipeline.paper_outputs.paths.figures
             / pipeline.paper_outputs.artifact_names.main_robustness_figure,
             description="Robustness of the model across a variety of stratifications. Blue line is the area under the receiver operating characteristics curve. Grey bars represent the proportion of visits that are present in each group. Error bars are 95%-confidence intervals from 100-fold bootstrap.",
-            relative_to=relative_to,
+            relative_to_path=relative_to,
         ),
         MarkdownTable(
             title=f"Performance of {pipeline.model_type} with {int(pipeline.inputs.cfg.preprocessing.pre_split.min_lookahead_days / 365)} years of lookahead by predicted positive rate (PPR). Numbers are physical contacts.",

--- a/src/psycop/projects/t2d/paper_outputs/aggregate_eval/supplementary_full_eval.py
+++ b/src/psycop/projects/t2d/paper_outputs/aggregate_eval/supplementary_full_eval.py
@@ -1,5 +1,5 @@
 import polars as pl
-from psycop.projects.t2d.paper_outputs.aggregate_eval.md_objects import (
+from psycop.common.model_evaluation.markdown.md_objects import (
     MarkdownArtifact,
     create_supplementary_from_markdown_artifacts,
 )

--- a/src/psycop/projects/t2d/paper_outputs/dataset_description/describe_features.py
+++ b/src/psycop/projects/t2d/paper_outputs/dataset_description/describe_features.py
@@ -93,7 +93,7 @@ predictor_description_path = (
 prettified.to_csv(predictor_description_path)
 
 # %%
-from psycop.projects.t2d.paper_outputs.aggregate_eval.md_objects import MarkdownTable
+from psycop.common.model_evaluation.markdown.md_objects import MarkdownTable
 
 md = MarkdownTable(
     title="## **eTable 2**: Descriptive statistics for predictors (a list of abbreviations is inserted below the table)",

--- a/tasks.py
+++ b/tasks.py
@@ -190,14 +190,12 @@ def branch_exists_on_remote(c: Context) -> bool:
     return branch_name in branch_exists_result.stdout
 
 
-def update_branch(c: Context):
+def push_to_branch(c: Context):
     echo_header(f"{msg_type.SYNC} Syncing branch with remote")
 
     if not branch_exists_on_remote(c):
         c.run("git push --set-upstream origin HEAD")
     else:
-        print("Pulling")
-        c.run("git pull")
         print("Pushing")
         c.run("git push")
 
@@ -416,7 +414,7 @@ def create_pr_from_staged_changes(c: Context):
     c.run("git checkout main")
     c.run(f"git checkout -b {branch_title}")
     c.run(f"git commit -m '{pr_title}'")
-    update_branch(c)
+    push_to_branch(c)
     update_pr(c)
 
     checkout_previous_branch = input("Checkout previous branch? [y/n]: ")
@@ -492,7 +490,7 @@ def pr(c: Context, auto_fix: bool = True):
     add_and_commit(c)
     lint(c, auto_fix=auto_fix)
     test(c)
-    update_branch(c)
+    push_to_branch(c)
     update_pr(c)
 
 


### PR DESCRIPTION
@HLasse, would strongly prefer a full review of:

`src/psycop/common/model_evaluation/markdown/md_objects.py`
`src/psycop/common/model_evaluation/markdown/test_md_objects.py`

if possible :-)

Fixes #76 if merged.