### PR TITLE
fix: remove round from static feature describer

### DIFF
--- a/psycop/common/feature_generation/data_checks/flattened/feature_describer.py
+++ b/psycop/common/feature_generation/data_checks/flattened/feature_describer.py
@@ -139,7 +139,7 @@ def generate_static_feature_description(
         "N unique": series.nunique(),
         "Fallback strategy": "N/A",
         "Proportion missing": series.isna().mean(),
-        "Mean": round(series.mean(), 2),
+        "Mean": series.mean(),
         "Proportion using fallback": "N/A",
     }
 


### PR DESCRIPTION
# Notes for reviewers
Flattened dataset description code broke when adding the birthday predictor because we couldn't round a timestamp. Removed the round for the static predictors, since the only other static predictor is sex_female, and that returns NaN anyways for mean.
