### PR TITLE
feat: add vscode PR task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,7 @@ cython_debug/
 #.idea/
 
 #VSCode
-# .vscode/*
+.vscode/*
 
 # Testing
 pytest-coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,7 @@ cython_debug/
 #.idea/
 
 #VSCode
-.vscode/*
+# .vscode/*
 
 # Testing
 pytest-coverage.txt

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "PR",
+            "type": "shell",
+            "command": "gh pr create -w",
+            "group": "test",
+            "dependsOn": [
+                "Lint",
+                "Test",
+                "Static type check"
+            ],
+            "presentation": {
+                "reveal": "always",
+                "group": "pr"
+            }
+        },
+        {
+            "label": "Lint",
+            "type": "shell",
+            "command": "inv lint",
+            "presentation": {
+                "reveal": "always",
+                "group": "pr"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "inv test",
+            "presentation": {
+                "reveal": "always",
+                "group": "pr"
+            },
+        },
+        {
+            "label": "Static type check",
+            "type": "shell",
+            "command": "inv static-type-checks",
+            "presentation": {
+                "reveal": "always",
+                "group": "pr"
+            }
+        }
+    ]
+}

--- a/tasks.py
+++ b/tasks.py
@@ -493,7 +493,6 @@ def lint(c: Context, auto_fix: bool = False):
     test_for_venv(c)
     test_for_rej(c)
     pre_commit(c=c, auto_fix=auto_fix)
-    static_type_checks(c)
 
 
 @task
@@ -501,6 +500,7 @@ def pr(c: Context, auto_fix: bool = True):
     """Run all checks and update the PR."""
     add_and_commit(c)
     lint(c, auto_fix=auto_fix)
+    static_type_checks(c)
     test(c)
     push_to_branch(c)
     update_pr(c)


### PR DESCRIPTION
Hi everyone!

The next time you pull, you can run a command equivalent to `inv pr` by running:

![image](https://github.com/Aarhus-Psychiatry-Research/psycop-common/assets/8526086/bf14aa77-0682-4ad6-a87f-2e3b2951c597)

In the VSCode command palette. Should make things even smoother 👍 