### PR TITLE
feat: allow levels of granularity in diagnosis mapping

### DIFF
--- a/psycop/common/sequence_models/embedders/BEHRT_embedders.py
+++ b/psycop/common/sequence_models/embedders/BEHRT_embedders.py
@@ -199,7 +199,17 @@ class BEHRTEmbedder(nn.Module):
         ) as fp:
             mapping = json.load(fp)
 
-        return [mapping[d] for d in diagnosis_codes if d in mapping]
+        # For each diagnosis code, attempt to map to caliber code
+        # If no mapping exists, remove one character from the end of the code and try again
+        mapped_diagnosis_codes = []
+        for d in diagnosis_codes:
+            while len(d) > 2:  # only attempt codes with at least 3 characters
+                if d in mapping:
+                    mapped_diagnosis_codes.append(mapping[d])
+                    break
+                d = d[:-1]  # noqa: PLW2901
+
+        return mapped_diagnosis_codes
 
     def collate_patient(self, patient: Patient) -> dict[str, torch.Tensor]:
         events = patient.temporal_events

--- a/psycop/common/sequence_models/embedders/BEHRT_embedders.py
+++ b/psycop/common/sequence_models/embedders/BEHRT_embedders.py
@@ -190,7 +190,7 @@ class BEHRTEmbedder(nn.Module):
                 filtered_events.append(event)
         return filtered_events
 
-    def get_mapped_diagnosis_codes(
+    def map_icd10_to_caliber(
         self,
         diagnosis_codes: list[str],
     ) -> list[str]:
@@ -267,7 +267,7 @@ class BEHRTEmbedder(nn.Module):
 
         # map diagnosis codes
         if map_diagnosis_codes:
-            diagnosis_codes = self.get_mapped_diagnosis_codes(
+            diagnosis_codes = self.map_icd10_to_caliber(
                 diagnosis_codes=diagnosis_codes,
             )
 

--- a/psycop/common/sequence_models/tests/test_embedding.py
+++ b/psycop/common/sequence_models/tests/test_embedding.py
@@ -95,7 +95,7 @@ def test_diagnosis_mapping(
     diagnosis_codes: list[str] = [e.value for p, e in patient_events]  # type: ignore
 
     # map diagnosis codes
-    mapped_diagnosis_codes = embedding_module.get_mapped_diagnosis_codes(
+    mapped_diagnosis_codes = embedding_module.map_icd10_to_caliber(
         diagnosis_codes=diagnosis_codes,
     )
 

--- a/psycop/common/sequence_models/tests/test_embedding.py
+++ b/psycop/common/sequence_models/tests/test_embedding.py
@@ -76,10 +76,17 @@ def test_diagnosis_mapping(
             source_type="diagnosis",
             source_subtype="A",
         ),
-        # Check that diagnosis codes that are not in the mapping are excluded
+        # Check that F909 is mapped to F90 (Hyperkinetic disorders) since F909 is not in the mapping
         TemporalEvent(
             timestamp=dt.datetime(2021, 1, 3),
-            value="I99999",
+            value="F909",
+            source_type="diagnosis",
+            source_subtype="A",
+        ),
+        # Check that codes that are not in the mapping are not mapped
+        TemporalEvent(
+            timestamp=dt.datetime(2021, 1, 3),
+            value="X999999",
             source_type="diagnosis",
             source_subtype="A",
         ),
@@ -103,4 +110,5 @@ def test_diagnosis_mapping(
         "Bacterial Diseases (excl TB)",
         "Bacterial Diseases (excl TB)",
         "Transient ischaemic attack",
+        "Hyperkinetic disorders",
     ]

--- a/psycop/common/sequence_models/tests/test_embedding.py
+++ b/psycop/common/sequence_models/tests/test_embedding.py
@@ -83,13 +83,6 @@ def test_diagnosis_mapping(
             source_type="diagnosis",
             source_subtype="A",
         ),
-        # Check that codes that are not in the mapping are not mapped
-        TemporalEvent(
-            timestamp=dt.datetime(2021, 1, 3),
-            value="X999999",
-            source_type="diagnosis",
-            source_subtype="A",
-        ),
     ]
 
     patient.add_events(temporal_events)

--- a/psycop/common/sequence_models/tests/test_embedding.py
+++ b/psycop/common/sequence_models/tests/test_embedding.py
@@ -41,7 +41,8 @@ def test_diagnosis_mapping(
     """
     Test mapping of diagnosis from ICD10 to caliber
     """
-
+    # Check that diagnosis codes that are not in the mapping are excluded
+    # (this patient has no diagnosis codes in the mapping)
     patient = Patient(
         patient_id=11,
         date_of_birth=dt.datetime(year=1990, month=1, day=1),


### PR DESCRIPTION
Noticed that we lose a lot of diagnoses when mapping from ICD-10 to CALIBER (~40% of patients have empty sequences after mapping).

CALIBER uses ICD-10 with three or four characters (e.g. "A20" and "A201").

Before, get_mapped_diagnoses_codes() matches the codes directly and if they do not exist in the mapping, it excludes them. Changed this so that it checks different levels of granularity, starting with the highest. (e.g. for "A201" it first checks for "A201" in the mapping and if that does not exist it checks for "A20" and then uses that, otherwise excludes it).

Now, only ~10% of patients have empty sequences after mapping.