### PR TITLE
dev: use docker buildkit cache for pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,16 @@ RUN apt-get update && apt-get install -y curl
 
 # Install dev tools
 COPY test-requirements.txt .
-RUN pip install -r test-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r test-requirements.txt
 
 COPY dev-requirements.txt .
-RUN pip install -r dev-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r dev-requirements.txt
 
 COPY gpu-requirements.txt .
-RUN pip install -r gpu-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r gpu-requirements.txt
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
This saves pip's cache so it can be used across rebuilds, dramatically improving performance on rebuild 👍 