### PR TITLE
dev: add quick PR using testmon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ logs/*
 # Allow mapping file to be uploaded
 !**/diagnosis_code_mapping.json
 !.devcontainer/devcontainer.json
+
+# Ignore testmon database
+.testmon*

--- a/tasks.py
+++ b/tasks.py
@@ -475,9 +475,23 @@ def pr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     static_type_checks(c)
     test(c)
 
+
 @task
-def qtest(c: Context):  # noqa: B006
-    test(c, pytest_args=["psycop", "-rfE", "--failed-first", "-p no:cov", "--disable-warnings", "-q", "--durations=5", "--testmon"])
+def qtest(c: Context):
+    test(
+        c,
+        pytest_args=[
+            "psycop",
+            "-rfE",
+            "--failed-first",
+            "-p no:cov",
+            "--disable-warnings",
+            "-q",
+            "--durations=5",
+            "--testmon",
+        ],
+    )
+
 
 @task
 def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
@@ -494,6 +508,7 @@ def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     push_to_branch(c)
     static_type_checks(c)
     qtest(c)
+
 
 @task
 def docs(c: Context, view: bool = False, view_only: bool = False):

--- a/tasks.py
+++ b/tasks.py
@@ -482,7 +482,7 @@ def qtest(c: Context):  # noqa: B006
 @task
 def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     """Run all checks and update the PR."""
-    c.run("gh pr create --fill", pty=NOT_WINDOWS, hide=True)
+    c.run("gh pr create --fill", pty=NOT_WINDOWS)
     add_and_commit(c)
     if create_pr:
         try:

--- a/tasks.py
+++ b/tasks.py
@@ -493,6 +493,8 @@ def qtest(c: Context):
     )
 
 
+# TODO: #390 Make more durable testmon implementation
+
 @task
 def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     """Run all checks and update the PR."""

--- a/tasks.py
+++ b/tasks.py
@@ -498,7 +498,6 @@ def qtest(c: Context):
 @task
 def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     """Run all checks and update the PR."""
-    c.run("gh pr create --fill", pty=NOT_WINDOWS)
     add_and_commit(c)
     if create_pr:
         try:

--- a/tasks.py
+++ b/tasks.py
@@ -475,6 +475,24 @@ def pr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     static_type_checks(c)
     test(c)
 
+@task
+def qtest(c: Context):  # noqa: B006
+    test(c, pytest_args=["psycop", "-rfE", "--failed-first", "-p no:cov", "--disable-warnings", "-q", "--durations=5", "--testmon"])
+
+@task
+def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
+    """Run all checks and update the PR."""
+    add_and_commit(c)
+    if create_pr:
+        try:
+            update_pr(c)
+        except Exception as e:
+            print(f"{msg_type.FAIL} Could not update PR: {e}. Continuing.")
+
+    lint(c, auto_fix=auto_fix)
+    push_to_branch(c)
+    static_type_checks(c)
+    qtest(c)
 
 @task
 def docs(c: Context, view: bool = False, view_only: bool = False):

--- a/tasks.py
+++ b/tasks.py
@@ -495,6 +495,7 @@ def qtest(c: Context):
 
 # TODO: #390 Make more durable testmon implementation
 
+
 @task
 def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     """Run all checks and update the PR."""

--- a/tasks.py
+++ b/tasks.py
@@ -482,6 +482,7 @@ def qtest(c: Context):  # noqa: B006
 @task
 def qpr(c: Context, auto_fix: bool = True, create_pr: bool = True):
     """Run all checks and update the PR."""
+    c.run("gh pr create --fill", pty=NOT_WINDOWS, hide=True)
     add_and_commit(c)
     if create_pr:
         try:


### PR DESCRIPTION
This adds an entrypoint for running tests using https://testmon.org/

> pytest-testmon is a pytest plugin which selects and executes only tests you need to run. It does this by collecting dependencies between tests and all executed code (internally using Coverage.py) and comparing the dependencies against changes. testmon updates its database on each test execution, so it works independently of version control.

This dramatically decreases our test run times, especially for a monorepo.

Potential downsides are false negatives. To avoid this, we still run the full test suite in CI.

I've added it as a separate entrypoint so we can test it, before suggesting it as an integration in everyone's workflow.  This is tracked in #390, so we don't forget.

Since it uses code coverage, it won't catch if you have changed an external file. E.g. if a .cfg file changes, any tests using the .cfg file won't run. I think that is fine as long as we run the full test suite remotely. Alternatively, we could run both locally. First testmon-tests (to get fast feedback), then all tests (to get comprehensive feedback).

@KennethEnevoldsen, @HLasse, what do you guys think? :-)