### PR TITLE
feat: ensure appropriate number of outcome columns

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "python.analysis.typeCheckingMode": "strict",
     "python.testing.pytestArgs": [
-        "."
+        "psycop"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/prefix_count_validator/prefix_count_validator_20231117_092246.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/prefix_count_validator/prefix_count_validator_20231117_092246.cfg
@@ -1,0 +1,6 @@
+
+# Example cfg for prefix_count_validator
+# You can find args at:
+#    psycop.common.model_training_v2.trainer.preprocessing.steps.column_validator
+[placeholder]
+test = ["prefix_", 2]

--- a/psycop/common/model_training_v2/config/populate_registry.py
+++ b/psycop/common/model_training_v2/config/populate_registry.py
@@ -37,8 +37,6 @@ def populate_baseline_registry() -> None:
         logistic_regression_step,
     )
 
-    
-
     # Suggesters
     from ..hyperparameter_suggester.hyperparameter_suggester import SuggesterSpace
 

--- a/psycop/common/model_training_v2/config/populate_registry.py
+++ b/psycop/common/model_training_v2/config/populate_registry.py
@@ -11,6 +11,14 @@ def populate_baseline_registry() -> None:
     # Loggers
     from ..loggers.base_logger import TerminalLogger
 
+    # Preprocessing
+    from ..trainer.preprocessing.pipeline import BaselinePreprocessingPipeline
+    from ..trainer.preprocessing.steps.row_filters import AgeFilter
+    from ..trainer.preprocessing.steps.column_validator import (
+        ColumnExistsValidator,
+        ColumnPrefixExpectation,
+    )
+
     # Trainers
     from ..trainer.cross_validator_trainer import CrossValidatorTrainer
     from ..trainer.split_trainer import SplitTrainer
@@ -29,12 +37,7 @@ def populate_baseline_registry() -> None:
         logistic_regression_step,
     )
 
-    # Preprocessing
-    from ..trainer.preprocessing.pipeline import BaselinePreprocessingPipeline
-    from ..trainer.preprocessing.steps.row_filters import AgeFilter
-    from ..trainer.preprocessing.steps.column_validator import (
-        ColumnExistsValidator,
-    )
+    
 
     # Suggesters
     from ..hyperparameter_suggester.hyperparameter_suggester import SuggesterSpace

--- a/psycop/common/model_training_v2/config/registries_testing_utils.py
+++ b/psycop/common/model_training_v2/config/registries_testing_utils.py
@@ -193,8 +193,8 @@ def generate_configs_from_registered_functions(
 
         raise Exception(
             f"""Encounted ConfigValidationErrors. For each, it means that either
-    a) No example config exists at the cfg dir. In this case, scaffolding-configs have been generated for you.
-    b) The function has changed in a way that breaks backwards compatability by e.g. adding a new, non-default argument.
+    a) No example config exists at the cfg dir. In this case, scaffolding-configs have been generated for you, which can be filled in with a valid example config. These ensure that, when we edit the file in the future, we are alerted if the edits are not backwards compatible.
+    b) The function has changed in a way that breaks backwards compatability by e.g. adding a new, non-default argument. In this case, you should create a new function with a new name in the (e.g. fn_v2), and register it in the registry. The old function should be archived in the archive folder.
 
 Errors:
 {fn_errors}

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -76,7 +76,6 @@ class ColumnCountExpectation:
         return cls(prefix=prefix, count=count) # type: ignore
 
 
-PrefixedColumnCountExpectation = tuple[str, int]
 @BaselineRegistry.preprocessing.register("column_exists_validator")
 class ColumnPrefixExpectation(PresplitStep):
     def __init__(

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -52,8 +52,6 @@ class ColumnExistsValidator(PresplitStep):
         return None
 
 
-
-
 class ColumnCountError(Exception):
     ...
 
@@ -64,7 +62,10 @@ class ColumnCountExpectation:
     count: int
 
     @classmethod
-    def from_list(cls: type["ColumnCountExpectation"], args: list[str | int]) -> "ColumnCountExpectation":
+    def from_list(
+        cls: type["ColumnCountExpectation"],
+        args: list[str | int],
+    ) -> "ColumnCountExpectation":
         if not len(args) == 2:
             raise ValueError(
                 f"ColumnCountExpectation.from_list() takes exactly 2 arguments, ({len(args)} given)",
@@ -72,7 +73,7 @@ class ColumnCountExpectation:
 
         prefix = args[0]
         count = args[1]  # noqa: F811
-        return cls(prefix=prefix, count=count) # type: ignore
+        return cls(prefix=prefix, count=count)  # type: ignore
 
 
 @BaselineRegistry.preprocessing.register("column_exists_validator")
@@ -96,7 +97,8 @@ class ColumnPrefixExpectation(PresplitStep):
             Seq(self.column_expectations)
             .map(
                 lambda expectation: self._column_count_as_expected(
-                    expectation=expectation, df=df,
+                    expectation=expectation,
+                    df=df,
                 ),
             )
             .flatten()

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import polars as pl
+from functionalpy import Seq
 from polars import LazyFrame
 
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
@@ -49,3 +51,71 @@ class ColumnExistsValidator(PresplitStep):
             return MissingColumnError(column_name=column_name)
 
         return None
+
+
+PrefixedColumnCountExpectation = tuple[str, int]
+
+
+class ColumnCountError(Exception):
+    ...
+
+
+@dataclass(frozen=True)
+class ColumnCountExpectation:
+    prefix: str
+    count: int
+
+
+@BaselineRegistry.preprocessing.register("column_exists_validator")
+class ColumnPrefixExpectation(PresplitStep):
+    def __init__(
+        self,
+        *args: PrefixedColumnCountExpectation,
+    ):
+        self.column_expectations = (
+            Seq(args)
+            .map(
+                lambda x: ColumnCountExpectation(prefix=x[0], count=x[1]),
+            )
+            .to_list()
+        )
+
+    def apply(self, input_df: PolarsFrame_T0) -> PolarsFrame_T0:
+        df = input_df.fetch(1) if isinstance(input_df, LazyFrame) else input_df
+
+        errors = (
+            Seq(self.column_expectations)
+            .map(
+                lambda expectation: self._column_count_as_expected(
+                    expectation=expectation, df=df,
+                ),
+            )
+            .flatten()
+        )
+
+        if errors:
+            missing_columns_str = ", ".join([e.column_name for e in errors])
+            raise ColumnCountError(
+                f"Column(s) [{missing_columns_str}] not found in dataset.",
+            )
+
+        return input_df
+
+    @staticmethod
+    def _column_count_as_expected(
+        expectation: ColumnCountExpectation,
+        df: pl.DataFrame,
+    ) -> Sequence[ColumnCountError]:
+        matching_columns = [
+            column for column in df.columns if column.startswith(expectation.prefix)
+        ]
+
+        if len(matching_columns) != expectation.count:
+            matched_columns_str = "\n\t".join(matching_columns)
+            return [
+                ColumnCountError(
+                    f'Number of columns with prefix {expectation.prefix} does not match expectation of {expectation.count}. Columns that matched: {matched_columns_str if matching_columns else "None"}',
+                ),
+            ]
+
+        return []

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -91,12 +91,13 @@ class ColumnPrefixExpectation(PresplitStep):
                 ),
             )
             .flatten()
+            .to_iter()
         )
 
         if errors:
-            missing_columns_str = ", ".join([e.column_name for e in errors])
             raise ColumnCountError(
-                f"Column(s) [{missing_columns_str}] not found in dataset.",
+                "Column count expectation(s) not met:\n\t"
+                + "\n\t".join([str(e) for e in errors]),
             )
 
         return input_df
@@ -105,7 +106,7 @@ class ColumnPrefixExpectation(PresplitStep):
     def _column_count_as_expected(
         expectation: ColumnCountExpectation,
         df: pl.DataFrame,
-    ) -> Sequence[ColumnCountError]:
+    ) -> list[ColumnCountError]:
         matching_columns = [
             column for column in df.columns if column.startswith(expectation.prefix)
         ]

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -1,9 +1,8 @@
-from collections.abc import Sequence
 from dataclasses import dataclass
 
 import polars as pl
 from functionalpy import Seq
-from polars import LazyFrame, count
+from polars import LazyFrame
 
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
 from psycop.common.model_training_v2.trainer.preprocessing.step import (
@@ -101,7 +100,7 @@ class ColumnPrefixExpectation(PresplitStep):
                 ),
             )
             .flatten()
-            .to_iter()
+            .to_list()
         )
 
         if errors:
@@ -113,7 +112,11 @@ class ColumnPrefixExpectation(PresplitStep):
         return input_df
 
     @staticmethod
+    def _wrap_str_in_quotes(string: str) -> str:
+        return f'"{string}"'
+
     def _column_count_as_expected(
+        self,
         expectation: ColumnCountExpectation,
         df: pl.DataFrame,
     ) -> list[ColumnCountError]:
@@ -122,10 +125,9 @@ class ColumnPrefixExpectation(PresplitStep):
         ]
 
         if len(matching_columns) != expectation.count:
-            matched_columns_str = "\n\t".join(matching_columns)
             return [
                 ColumnCountError(
-                    f'Number of columns with prefix {expectation.prefix} does not match expectation of {expectation.count}. Columns that matched: {matched_columns_str if matching_columns else "None"}',
+                    f'{self._wrap_str_in_quotes(expectation.prefix)} matched {matching_columns if matching_columns else "None"}, expected {expectation.count}.',
                 ),
             ]
 

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -76,7 +76,7 @@ class ColumnCountExpectation:
         return cls(prefix=prefix, count=count)  # type: ignore
 
 
-@BaselineRegistry.preprocessing.register("column_exists_validator")
+@BaselineRegistry.preprocessing.register("prefix_count_validator")
 class ColumnPrefixExpectation(PresplitStep):
     def __init__(
         self,

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/test_v2_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/test_v2_filters.py
@@ -82,16 +82,14 @@ def test_columns_exist_validator():
     ):
         ColumnExistsValidator("pred_age", "unknown_column").apply(df)
 
+
 def test_column_prefix_expectation():
-    df = (
-        str_to_pl_df(
-            """
+    df = str_to_pl_df(
+        """
         pred_age,
         1,
     """,
-        )
-        .lazy()
-    )
+    ).lazy()
 
     # Check passing test
     ColumnPrefixExpectation(["pred_", 1]).apply(df)

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/test_v2_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/test_v2_filters.py
@@ -6,7 +6,9 @@ from psycop.common.model_training_v2.trainer.preprocessing.steps.col_filters imp
     LookbehindCombinationColFilter,
 )
 from psycop.common.model_training_v2.trainer.preprocessing.steps.column_validator import (
+    ColumnCountError,
     ColumnExistsValidator,
+    ColumnPrefixExpectation,
     MissingColumnError,
 )
 from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filters import (
@@ -57,7 +59,7 @@ def test_lookbehind_combination_filter():
     assert len(result.columns) == 3
 
 
-def test_column_validator():
+def test_columns_exist_validator():
     df = (
         str_to_pl_df(
             """
@@ -79,3 +81,24 @@ def test_column_validator():
         match=r".+\[unknown_column\] not found in dataset.*",
     ):
         ColumnExistsValidator("pred_age", "unknown_column").apply(df)
+
+def test_column_prefix_expectation():
+    df = (
+        str_to_pl_df(
+            """
+        pred_age,
+        1,
+    """,
+        )
+        .lazy()
+    )
+
+    # Check passing test
+    ColumnPrefixExpectation(["pred_", 1]).apply(df)
+
+    # Fail
+    with pytest.raises(
+        ColumnCountError,
+        match=r".+count expectation.*",
+    ):
+        ColumnPrefixExpectation(["pred_", 2]).apply(df)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ confection==0.1.3
 deepchecks==0.17.0
 dill==0.3.6
 fakeredis==2.20.0
-functionalpy==0.10.0
+functionalpy==0.12.0
 hydra-core==1.3.2
 hydra-joblib-launcher==1.2.0
 hydra-optuna-sweeper==1.2.0


### PR DESCRIPTION
- Fixes #435

Ensuring that the correct columns are passed seems like a concern for the dataloaders. However, we probably want to validate it anyway, since messing up here could mean big trouble. I've added a simple preprocessing validation step to check for it.