### PR TITLE
docs: minor renames in behrt

### DIFF
--- a/psycop/common/sequence_models/tests/test_embedding.py
+++ b/psycop/common/sequence_models/tests/test_embedding.py
@@ -92,7 +92,7 @@ def test_diagnosis_mapping(
     patient_events: list[tuple[Patient, TemporalEvent]] = [
         (p, e)
         for p in [patient]
-        for e in embedding_module.filter_events(p.temporal_events)
+        for e in embedding_module.A_diagnoses_only(p.temporal_events)
     ]
     diagnosis_codes: list[str] = [e.value for p, e in patient_events]  # type: ignore
 
@@ -167,7 +167,7 @@ def test_reformat_and_filter(
     ]
 
     patient.add_events(temporal_events)
-    patient_slices_mapped = embedding_module.filter_and_reformat_events(
+    patient_slices_mapped = embedding_module.A_diagnoses_to_caliber(
         [patient.as_slice()],
     )
     diagnosis_codes = [

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -88,4 +88,4 @@ def train(config_path: Path | None = None) -> None:
 
     std_logger.info("Starting training")
     torch.set_float32_matmul_precision("medium")
-    trainer.fit(model=model, train_dataloaders=train_loader, val_dataloaders=val_loader)  # type: ignore
+    trainer.fit(model=model, train_dataloaders=train_loader, val_dataloaders=val_loader)

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -61,7 +61,7 @@ def train(config_path: Path | None = None) -> None:
 
     # filter dataset
     std_logger.info("Filtering Patients")
-    filter_fn = model.embedding_module.filter_and_reformat_events
+    filter_fn = model.embedding_module.A_diagnoses_to_caliber
     training_dataset.filter_patients(filter_fn)
     validation_dataset.filter_patients(filter_fn)
 


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->

1. Rename `filter_events` to `A_diagnoses_only` to convey content. This makes it less general; if we want to avoid that, perhaps we should conform to a `Protocol`?
2. Add documentation of Caliber codes