### PR TITLE
dev: add pytorch deps to `inv install`

### DIFF
--- a/psycop/automation/environment.py
+++ b/psycop/automation/environment.py
@@ -1,5 +1,7 @@
 import platform
 
+from invoke import Context, task
+
 NOT_WINDOWS = platform.system() != "Windows"
 
 
@@ -12,3 +14,12 @@ def on_ovartaci() -> bool:
 
     print("Not on Ovartaci")
     return False
+
+
+def test_pytorch_cuda(c: Context):
+    python_command = "import torch; t=torch.tensor(1); t.to(torch.device('cuda'))"
+    c.run(
+        f'python -c "{python_command}"',
+        pty=NOT_WINDOWS,
+    )
+    print("Pytorch CUDA works!")

--- a/psycop/automation/environment.py
+++ b/psycop/automation/environment.py
@@ -1,6 +1,6 @@
 import platform
 
-from invoke import Context, task
+from invoke import Context
 
 NOT_WINDOWS = platform.system() != "Windows"
 

--- a/setup_overtaci.sh
+++ b/setup_overtaci.sh
@@ -1,7 +1,0 @@
-# The only ground truth on how to set things up on Overtaci
-
-pip install -r requirements.txt -r dev-requirements.txt -r gpu-requirements.txt
-conda install pytorch=2.1.0 pytorch-cuda=12.1 -c https://exrhel0371.it.rm.dk/api/repo/pytorch -c https://exrhel0371.it.rm.dk/api/repo/nvidia -c https://exrhel0371.it.rm.dk/api/repo/anaconda --override-channels --insecure -y
-
-# test environment
-python -c "import torch; t=torch.tensor(1); t.to(torch.device('cuda'))"

--- a/tasks.py
+++ b/tasks.py
@@ -35,7 +35,7 @@ from psycop.automation.logger import echo_header, msg_type
 def install_requirements(c: Context):
     requirements_files = Path().parent.glob("*requirements.txt")
     requirements_string = " -r ".join([str(file) for file in requirements_files])
-    c.run(f"pip install -r {requirements_string}")
+    c.run(f"pip install --upgrade -r {requirements_string}")
 
     if on_ovartaci():
         # Install pytorch with cuda from private repo
@@ -46,6 +46,8 @@ def install_requirements(c: Context):
 
         # Test that cuda works
     c.run(r"python -c \"import torch; t=torch.tensor(1); t.to(torch.device('cuda'))\"")
+    print(f"{msg_type.GOOD} Pytorch CUDA works!")
+    print(f"{msg_type.GOOD} Newest version of all requirements installed!")
 
 
 @task(aliases=("static_type_checks", "type_check"))

--- a/tasks.py
+++ b/tasks.py
@@ -37,6 +37,16 @@ def install_requirements(c: Context):
     requirements_string = " -r ".join([str(file) for file in requirements_files])
     c.run(f"pip install -r {requirements_string}")
 
+    if on_ovartaci():
+        # Install pytorch with cuda from private repo
+        c.run(
+            "conda install --force-reinstall pytorch=2.1.0 pytorch-cuda=12.1 -c https://exrhel0371.it.rm.dk/api/repo/pytorch -c https://exrhel0371.it.rm.dk/api/repo/nvidia -c https://exrhel0371.it.rm.dk/api/repo/anaconda --override-channels --insecure -y",
+            pty=NOT_WINDOWS,
+        )
+
+        # Test that cuda works
+    c.run(r"python -c \"import torch; t=torch.tensor(1); t.to(torch.device('cuda'))\"")
+
 
 @task(aliases=("static_type_checks", "type_check"))
 def types(c: Context):

--- a/tasks.py
+++ b/tasks.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from invoke import Context, Result, task
 
-from psycop.automation.environment import NOT_WINDOWS, on_ovartaci
+from psycop.automation.environment import NOT_WINDOWS, test_pytorch_cuda, on_ovartaci
 from psycop.automation.git import (
     add_and_commit,
     filetype_modified_since_main,
@@ -43,10 +43,8 @@ def install_requirements(c: Context):
             "conda install --force-reinstall pytorch=2.1.0 pytorch-cuda=12.1 -c https://exrhel0371.it.rm.dk/api/repo/pytorch -c https://exrhel0371.it.rm.dk/api/repo/nvidia -c https://exrhel0371.it.rm.dk/api/repo/anaconda --override-channels --insecure -y",
             pty=NOT_WINDOWS,
         )
+        test_pytorch_cuda(c)
 
-        # Test that cuda works
-    c.run(r"python -c \"import torch; t=torch.tensor(1); t.to(torch.device('cuda'))\"")
-    print(f"{msg_type.GOOD} Pytorch CUDA works!")
     print(f"{msg_type.GOOD} Newest version of all requirements installed!")
 
 


### PR DESCRIPTION
@HLasse, @bokajgd FYI, no need to review if you don't want to.

Currently, running `inv install-requirements` on Ovartaci overrides torch with a version that does not have CUDA compiled. This is obviously a problem.

I tried getting it back into a consistent state by running `setup_ovartaci.sh`:
```bash
conda install pytorch=2.1.0 pytorch-cuda=12.1 -c https://exrhel0371.it.rm.dk/api/repo/pytorch -c https://exrhel0371.it.rm.dk/api/repo/nvidia -c https://exrhel0371.it.rm.dk/api/repo/anaconda --override-channels --insecure -y
```

But that did not solve the problem.

### Changes
* Moved all the handling into `inv install-requirements`, so we only have one entrypoint.
* Added `--force-reinstall` to the conda command, since that overrides the pip-installed torch with torch compiled for CUDA.

Fixes #552.