### PR TITLE
feat: pretrain with `mlflow`

### DIFF
--- a/psycop/common/feature_generation/sequences/patient_loaders.py
+++ b/psycop/common/feature_generation/sequences/patient_loaders.py
@@ -1,7 +1,7 @@
 import datetime
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Union
+from typing import TypeVar, Union
 
 import polars as pl
 

--- a/psycop/common/feature_generation/sequences/patient_loaders.py
+++ b/psycop/common/feature_generation/sequences/patient_loaders.py
@@ -1,7 +1,7 @@
 import datetime
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TypeVar, Union
+from typing import Union
 
 import polars as pl
 

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -2,6 +2,7 @@
 The config Schema for sequence models.
 """
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -100,4 +101,4 @@ class ResolvedConfigSchema(BaseModel):
     # Required because dataset and model are coupled through their input and outputs
     model_and_dataset: PretrainingModelAndDataset | ClassificationModelAndDataset
     training: TrainingConfigSchema
-    logger: plLogger | None = None
+    logger: Sequence[plLogger] | None = None

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Union
 
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.loggers import Logger as plLogger
-from lightning.pytorch.loggers.wandb import WandbLogger
 from pydantic import BaseModel
 
 from psycop.common.sequence_models.tasks import (

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -15,7 +15,7 @@ from psycop.common.sequence_models.tasks import (
 )
 
 from .dataset import PatientSliceDataset, PatientSlicesWithLabels
-from .logger import LoggerCreator
+from .logger import LoggerFactory
 
 
 class TrainerConfigSchema(BaseModel):
@@ -101,4 +101,4 @@ class ResolvedConfigSchema(BaseModel):
     # Required because dataset and model are coupled through their input and outputs
     model_and_dataset: PretrainingModelAndDataset | ClassificationModelAndDataset
     training: TrainingConfigSchema
-    logger: LoggerCreator | None
+    logger_factory: LoggerFactory | None

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -24,7 +24,7 @@ class TrainerConfigSchema(BaseModel):
     """
 
     class Config:
-        allow_mutation = True
+        allow_mutation = False
         arbitrary_types_allowed = True
 
     accelerator: str = "auto"

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -15,7 +15,7 @@ from psycop.common.sequence_models.tasks import (
 )
 
 from .dataset import PatientSliceDataset, PatientSlicesWithLabels
-from .logger import Logger
+from .logger import LoggerCreator
 
 
 class TrainerConfigSchema(BaseModel):
@@ -24,7 +24,7 @@ class TrainerConfigSchema(BaseModel):
     """
 
     class Config:
-        allow_mutation = False
+        allow_mutation = True
         arbitrary_types_allowed = True
 
     accelerator: str = "auto"
@@ -63,6 +63,7 @@ class TrainingConfigSchema(BaseModel):
     class Config:
         extra = "forbid"
         arbitrary_types_allowed = True
+        allow_mutations = False
 
     batch_size: int
     num_workers_for_dataloader: int = 8
@@ -100,4 +101,4 @@ class ResolvedConfigSchema(BaseModel):
     # Required because dataset and model are coupled through their input and outputs
     model_and_dataset: PretrainingModelAndDataset | ClassificationModelAndDataset
     training: TrainingConfigSchema
-    logger: Logger | None
+    logger: LoggerCreator | None

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -15,7 +15,6 @@ from psycop.common.sequence_models.tasks import (
 )
 
 from .dataset import PatientSliceDataset, PatientSlicesWithLabels
-from .logger import LoggerFactory
 
 
 class TrainerConfigSchema(BaseModel):
@@ -101,4 +100,4 @@ class ResolvedConfigSchema(BaseModel):
     # Required because dataset and model are coupled through their input and outputs
     model_and_dataset: PretrainingModelAndDataset | ClassificationModelAndDataset
     training: TrainingConfigSchema
-    logger_factory: LoggerFactory | None
+    logger: plLogger | None = None

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.loggers import Logger as plLogger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from pydantic import BaseModel
 
@@ -15,6 +16,7 @@ from psycop.common.sequence_models.tasks import (
 )
 
 from .dataset import PatientSliceDataset, PatientSlicesWithLabels
+from .logger import Logger
 
 
 class TrainerConfigSchema(BaseModel):
@@ -32,7 +34,7 @@ class TrainerConfigSchema(BaseModel):
     num_nodes: int = 1
     callbacks: list[Callback] = []
     precision: str = "32-true"
-    logger: Optional[WandbLogger] = None
+    logger: Optional[plLogger] = None
     max_epochs: Optional[int] = None
     min_epochs: Optional[int] = None
     max_steps: int = 10
@@ -61,7 +63,6 @@ class TrainerConfigSchema(BaseModel):
 class TrainingConfigSchema(BaseModel):
     class Config:
         extra = "forbid"
-        allow_mutation = False
         arbitrary_types_allowed = True
 
     batch_size: int
@@ -100,3 +101,4 @@ class ResolvedConfigSchema(BaseModel):
     # Required because dataset and model are coupled through their input and outputs
     model_and_dataset: PretrainingModelAndDataset | ClassificationModelAndDataset
     training: TrainingConfigSchema
+    logger: Logger | None

--- a/psycop/common/sequence_models/config_schema.py
+++ b/psycop/common/sequence_models/config_schema.py
@@ -62,8 +62,8 @@ class TrainerConfigSchema(BaseModel):
 class TrainingConfigSchema(BaseModel):
     class Config:
         extra = "forbid"
+        allow_mutation = False
         arbitrary_types_allowed = True
-        allow_mutations = False
 
     batch_size: int
     num_workers_for_dataloader: int = 8

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -23,67 +23,36 @@ def handle_wandb_folder():
         )
 
 
-@runtime_checkable
-class LoggerFactory(Protocol):
-    def __init__(
-        self,
-        save_dir: Path | str,
-        experiment_name: str,
-        run_name: Optional[str] = None,
-        offline: bool = False,
-    ) -> None:
-        ...
-
-    def get_logger(
-        self,
-    ) -> plLogger:
-        ...
-
-
 @Registry.loggers.register("wandb")
-class WandbCreator(LoggerFactory):
-    def __init__(
-        self,
-        save_dir: Path | str,
-        experiment_name: str,
-        offline: bool,
-        run_name: Optional[str] = None,
-    ) -> None:
-        handle_wandb_folder()
+def create_wandb_logger(
+    save_dir: Path | str,
+    experiment_name: str,
+    offline: bool,
+    run_name: Optional[str] = None,
+) -> plLogger:
+    handle_wandb_folder()
 
-        self.save_dir = save_dir
-        self.experiment_name = experiment_name
-        self.run_name = run_name
-        self.offline = offline
-
-    def get_logger(self) -> plLogger:
-        return plWandbLogger(
-            name=self.run_name,
-            save_dir=f"{self.save_dir}/{self.experiment_name}/{self.run_name}",
-            offline=self.offline,
-            project=self.experiment_name,
-        )
+    return plWandbLogger(
+        name=run_name,
+        save_dir=f"{save_dir}/{experiment_name}/{run_name}",
+        offline=offline,
+        project=experiment_name,
+    )
 
 
 @Registry.loggers.register("mlflow")
-class MLFlowCreator(LoggerFactory):
-    def __init__(
-        self,
-        save_dir: Path | str,
-        experiment_name: str,
-        offline: bool = False,
-        run_name: Optional[str] = None,
-    ) -> None:
-        self.save_dir = save_dir
-        self.experiment_name = experiment_name
-        self.run_name = run_name
-        if offline:
-            raise NotImplementedError("MLFlow does not support offline mode")
+def create_mlflow_logger(
+    save_dir: Path | str,
+    experiment_name: str,
+    offline: bool = False,
+    run_name: Optional[str] = None,
+) -> plLogger:
+    if offline:
+        raise NotImplementedError("MLFlow does not support offline mode")
 
-    def get_logger(self) -> plLogger:
-        return plMLFlowLogger(
-            save_dir=f"{self.save_dir}/{self.experiment_name}/{self.run_name}",
-            experiment_name=self.experiment_name,
-            run_name=self.run_name,
-            tracking_uri="http://exrhel0371.it.rm.dk:5050",
-        )
+    return plMLFlowLogger(
+        save_dir=f"{save_dir}/{experiment_name}/{run_name}",
+        experiment_name=experiment_name,
+        run_name=run_name,
+        tracking_uri="http://exrhel0371.it.rm.dk:5050",
+    )

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -51,7 +51,7 @@ def create_mlflow_logger(
         raise NotImplementedError("MLFlow does not support offline mode")
 
     return plMLFlowLogger(
-        save_dir=save_dir,
+        save_dir=str(save_dir),
         experiment_name=experiment_name,
         run_name=run_name,
         tracking_uri="http://exrhel0371.it.rm.dk:5050",

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -1,7 +1,8 @@
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Literal, Optional
 
+from lightning.pytorch.loggers.mlflow import MLFlowLogger
 from lightning.pytorch.loggers.wandb import WandbLogger
 
 from .registry import Registry
@@ -44,4 +45,29 @@ def create_wandb_logger(
         project=project,
         prefix=prefix,
         checkpoint_name=checkpoint_name,
+    )
+
+
+@Registry.loggers.register("mlflow")
+def create_mlflow_logger(
+    experiment_name: str,
+    metric_prefix: str,
+    run_name: Optional[str] = None,
+    tracking_uri: Optional[str] = "http://exrhel0371.it.rm.dk:5050",
+    tags: Optional[dict[str, Any]] = None,
+    save_dir: Optional[str] = None,
+    log_model_checkpoints_to_mlflow: Literal[True, False, "all"] = False,
+    artifact_location: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> MLFlowLogger:
+    return MLFlowLogger(
+        experiment_name=experiment_name,
+        prefix=metric_prefix,
+        run_name=run_name,
+        tracking_uri=tracking_uri,
+        tags=tags,
+        save_dir=save_dir,
+        log_model=log_model_checkpoints_to_mlflow,
+        artifact_location=artifact_location,
+        run_id=run_id,
     )

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -34,7 +34,7 @@ def create_wandb_logger(
 
     return plWandbLogger(
         name=run_name,
-        save_dir=f"{save_dir}/{experiment_name}/{run_name}",
+        save_dir=save_dir,
         offline=offline,
         project=experiment_name,
     )
@@ -51,7 +51,7 @@ def create_mlflow_logger(
         raise NotImplementedError("MLFlow does not support offline mode")
 
     return plMLFlowLogger(
-        save_dir=f"{save_dir}/{experiment_name}/{run_name}",
+        save_dir=save_dir,
         experiment_name=experiment_name,
         run_name=run_name,
         tracking_uri="http://exrhel0371.it.rm.dk:5050",

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -24,7 +24,7 @@ def handle_wandb_folder():
 
 
 @runtime_checkable
-class Logger(Protocol):
+class LoggerCreator(Protocol):
     def __init__(
         self,
         save_dir: Path | str,
@@ -41,7 +41,7 @@ class Logger(Protocol):
 
 
 @Registry.loggers.register("wandb")
-class WandbCreator(Logger):
+class WandbCreator(LoggerCreator):
     def __init__(
         self,
         save_dir: Path | str,
@@ -66,7 +66,7 @@ class WandbCreator(Logger):
 
 
 @Registry.loggers.register("mlflow")
-class MLFlowCreator(Logger):
+class MLFlowCreator(LoggerCreator):
     def __init__(
         self,
         save_dir: Path | str,

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Optional, Protocol, runtime_checkable
+from typing import Optional
 
 from lightning.pytorch.loggers import Logger as plLogger
 from lightning.pytorch.loggers.mlflow import MLFlowLogger as plMLFlowLogger

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -21,41 +21,39 @@ def handle_wandb_folder():
 
 @Registry.loggers.register("wandb")
 def create_wandb_logger(
-    name: Optional[str] = None,
-    save_dir: Path | str = ".",
+    save_dir: Path | str,
+    experiment_name: str,
+    metric_prefix: str = "",
+    run_name: Optional[str] = None,
     version: Optional[str] = None,
     offline: bool = False,
-    dir: Optional[Path] = None,  # noqa: A002
     id: Optional[str] = None,  # noqa: A002
     anonymous: Optional[bool] = None,
-    project: Optional[str] = None,
-    prefix: str = "",
     checkpoint_name: Optional[str] = None,
 ) -> WandbLogger:
     handle_wandb_folder()
 
     return WandbLogger(
-        name=name,
+        name=run_name,
         save_dir=save_dir,
         version=version,
         offline=offline,
-        dir=dir,
         id=id,
         anonymous=anonymous,
-        project=project,
-        prefix=prefix,
+        project=experiment_name,
+        prefix=metric_prefix,
         checkpoint_name=checkpoint_name,
     )
 
 
 @Registry.loggers.register("mlflow")
 def create_mlflow_logger(
+    save_dir: str,
     experiment_name: str,
-    metric_prefix: str,
     run_name: Optional[str] = None,
+    metric_prefix: str = "",
     tracking_uri: Optional[str] = "http://exrhel0371.it.rm.dk:5050",
     tags: Optional[dict[str, Any]] = None,
-    save_dir: Optional[str] = None,
     log_model_checkpoints_to_mlflow: Literal[True, False, "all"] = False,
     artifact_location: Optional[str] = None,
     run_id: Optional[str] = None,

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -35,7 +35,7 @@ def create_wandb_logger(
 
     return WandbLogger(
         name=run_name,
-        save_dir=save_dir,
+        save_dir=f"{save_dir}/{experiment_name}/{run_name}",
         version=version,
         offline=offline,
         id=id,
@@ -64,7 +64,7 @@ def create_mlflow_logger(
         run_name=run_name,
         tracking_uri=tracking_uri,
         tags=tags,
-        save_dir=save_dir,
+        save_dir=f"{save_dir}/{experiment_name}/{run_name}",
         log_model=log_model_checkpoints_to_mlflow,
         artifact_location=artifact_location,
         run_id=run_id,

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -24,7 +24,7 @@ def handle_wandb_folder():
 
 
 @runtime_checkable
-class LoggerCreator(Protocol):
+class LoggerFactory(Protocol):
     def __init__(
         self,
         save_dir: Path | str,
@@ -41,7 +41,7 @@ class LoggerCreator(Protocol):
 
 
 @Registry.loggers.register("wandb")
-class WandbCreator(LoggerCreator):
+class WandbCreator(LoggerFactory):
     def __init__(
         self,
         save_dir: Path | str,
@@ -66,7 +66,7 @@ class WandbCreator(LoggerCreator):
 
 
 @Registry.loggers.register("mlflow")
-class MLFlowCreator(LoggerCreator):
+class MLFlowCreator(LoggerFactory):
     def __init__(
         self,
         save_dir: Path | str,

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional, Protocol, runtime_checkable
 
 from lightning.pytorch.loggers import Logger as plLogger
 from lightning.pytorch.loggers.mlflow import MLFlowLogger as plMLFlowLogger
@@ -23,6 +23,7 @@ def handle_wandb_folder():
         )
 
 
+@runtime_checkable
 class Logger(Protocol):
     def __init__(
         self,

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Literal, Optional, Protocol
+from typing import Optional, Protocol
 
 from lightning.pytorch.loggers import Logger as plLogger
 from lightning.pytorch.loggers.mlflow import MLFlowLogger as plMLFlowLogger

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from pathlib import Path
 from typing import Optional
@@ -8,8 +7,6 @@ from lightning.pytorch.loggers.mlflow import MLFlowLogger as plMLFlowLogger
 from lightning.pytorch.loggers.wandb import WandbLogger as plWandbLogger
 
 from .registry import Registry
-
-log = logging.getLogger(__name__)
 
 
 def handle_wandb_folder():

--- a/psycop/common/sequence_models/registry.py
+++ b/psycop/common/sequence_models/registry.py
@@ -1,3 +1,5 @@
+from typing import TypeVar
+
 import catalogue
 from confection import registry
 
@@ -13,3 +15,13 @@ class Registry(registry):
     optimizers = catalogue.create("psycop", "optimizers")
     lr_schedulers = catalogue.create("psycop", "lr_schedulers")
     callbacks = catalogue.create("psycop", "callbacks")
+
+    utilities = catalogue.create("psycop", "utilities")
+
+
+T = TypeVar("T")
+
+
+@Registry.utilities.register("list_creator")
+def list_creator(*args: T) -> list[T]:
+    return list(args)

--- a/psycop/common/sequence_models/tests/test_config.cfg
+++ b/psycop/common/sequence_models/tests/test_config.cfg
@@ -49,7 +49,7 @@ save_dir = ${logger.save_dir}
 logging_interval = "epoch"
 
 
-[logger]
+[logger_factory]
 @loggers = "wandb"
 save_dir = "logs/"
 experiment_name = "test_experiment"

--- a/psycop/common/sequence_models/tests/test_config.cfg
+++ b/psycop/common/sequence_models/tests/test_config.cfg
@@ -1,6 +1,3 @@
-
-
-
 [training]
 batch_size=64
 num_workers_for_dataloader=2
@@ -42,14 +39,17 @@ monitor = "val_loss"
 save_top_k = 5
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger_factory.save_dir}
+save_dir = ${logger.*.wandb.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
 
-[logger_factory]
+[logger]
+@utilities = "list_creator"
+
+[logger.*.wandb]
 @loggers = "wandb"
 save_dir = "logs/"
 experiment_name = "test_experiment"

--- a/psycop/common/sequence_models/tests/test_config.cfg
+++ b/psycop/common/sequence_models/tests/test_config.cfg
@@ -51,15 +51,9 @@ logging_interval = "epoch"
 
 [training.trainer.logger]
 @loggers = "wandb"
-name = null
+experiment_name = "test_experiment"
+run_name = "test_run"
 save_dir = "logs/"
-version = null
-offline = true
-dir = null
-id = null
-anonymous = null
-project = "psycop"
-checkpoint_name = null
 
 [model_and_dataset]
 [model_and_dataset.model]

--- a/psycop/common/sequence_models/tests/test_config.cfg
+++ b/psycop/common/sequence_models/tests/test_config.cfg
@@ -42,7 +42,7 @@ monitor = "val_loss"
 save_top_k = 5
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger.save_dir}
+save_dir = ${logger_factory.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"

--- a/psycop/common/sequence_models/tests/test_config.cfg
+++ b/psycop/common/sequence_models/tests/test_config.cfg
@@ -54,6 +54,7 @@ logging_interval = "epoch"
 experiment_name = "test_experiment"
 run_name = "test_run"
 save_dir = "logs/"
+offline = true
 
 [model_and_dataset]
 [model_and_dataset.model]

--- a/psycop/common/sequence_models/tests/test_config.cfg
+++ b/psycop/common/sequence_models/tests/test_config.cfg
@@ -42,18 +42,18 @@ monitor = "val_loss"
 save_top_k = 5
 every_n_epochs = 1
 mode = "min"
-save_dir = ${training.trainer.logger.save_dir}
+save_dir = ${logger.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
 
-[training.trainer.logger]
+[logger]
 @loggers = "wandb"
+save_dir = "logs/"
 experiment_name = "test_experiment"
 run_name = "test_run"
-save_dir = "logs/"
 offline = true
 
 [model_and_dataset]

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -13,7 +13,7 @@ from psycop.common.global_utils.config_utils import flatten_nested_dict
 
 from .config_utils import load_config, parse_config
 
-std_logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 os.environ["WANDB__SERVICE_WAIT"] = "300"  # to avoid issues with wandb service
 
 
@@ -54,7 +54,7 @@ def train(config_path: Path | None = None) -> None:
         training_cfg.logger = logger
 
         # update config
-        std_logger.info("Updating Config")
+        log.info("Updating Config")
         flat_config = flatten_nested_dict(config_dict)
         logger.log_hyperparams(flat_config)
 
@@ -64,15 +64,13 @@ def train(config_path: Path | None = None) -> None:
     logger = config.logger.get_logger()
     trainer_kwargs = training_cfg.trainer.to_dict()
 
-    if logger:
-
     # filter dataset
-    std_logger.info("Filtering Patients")
+    log.info("Filtering Patients")
     filter_fn = model.filter_and_reformat
     training_dataset.filter_patients(filter_fn)
     validation_dataset.filter_patients(filter_fn)
 
-    std_logger.info("Creating dataloaders")
+    log.info("Creating dataloaders")
     train_loader = DataLoader(
         training_dataset,
         batch_size=training_cfg.batch_size,
@@ -90,9 +88,9 @@ def train(config_path: Path | None = None) -> None:
         persistent_workers=True,
     )
 
-    std_logger.info("Initalizing trainer")
+    log.info("Initalizing trainer")
     trainer = pl.Trainer(**trainer_kwargs)
 
-    std_logger.info("Starting training")
+    log.info("Starting training")
     torch.set_float32_matmul_precision("medium")
     trainer.fit(model=model, train_dataloaders=train_loader, val_dataloaders=val_loader)

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -32,7 +32,6 @@ def populate_registry() -> None:
     from .optimizers import create_adamw  # noqa
     from .optimizers import create_linear_schedule_with_warmup  # noqa
     from .tasks import create_behrt, clf_encoder  # noqa
-    from .registry import list_creator
 
 
 populate_registry()

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -51,7 +51,8 @@ def train(config_path: Path | None = None) -> None:
     training_cfg = config.training
     if config.logger is not None:
         logger = config.logger.get_logger()
-        training_cfg.logger = logger
+        training_cfg.trainer.logger = logger
+        training_cfg.trainer.Config.allow_mutation = False
 
         # update config
         log.info("Updating Config")

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -26,7 +26,7 @@ def populate_registry() -> None:
     """
     from .callbacks import create_learning_rate_monitor, create_model_checkpoint  # noqa
     from .embedders.BEHRT_embedders import create_behrt_embedder  # noqa
-    from .logger import create_wandb_logger  # noqa
+    from .logger import WandbCreator, MLFlowCreator  # noqa
     from .model_layers import create_encoder_layer, create_transformers_encoder  # noqa
     from .optimizers import create_adam  # noqa
     from .optimizers import create_adamw  # noqa
@@ -47,19 +47,24 @@ def train(config_path: Path | None = None) -> None:
     config_dict = load_config(config_path)
     config = parse_config(config_dict)
 
+    # Setup the logger and pass it to the TrainingConfig
     training_cfg = config.training
+    if config.logger is not None:
+        logger = config.logger.get_logger()
+        training_cfg.logger = logger
+
+        # update config
+        std_logger.info("Updating Config")
+        flat_config = flatten_nested_dict(config_dict)
+        logger.log_hyperparams(flat_config)
+
     training_dataset = config.model_and_dataset.training_dataset
     validation_dataset = config.model_and_dataset.validation_dataset
     model = config.model_and_dataset.model
-    logger = training_cfg.trainer.logger
+    logger = config.logger.get_logger()
     trainer_kwargs = training_cfg.trainer.to_dict()
 
-    # update config
-    std_logger.info("Updating Config")
-    flat_config = flatten_nested_dict(config_dict)
-
     if logger:
-        logger.experiment.config.update(flat_config)
 
     # filter dataset
     std_logger.info("Filtering Patients")

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -32,6 +32,7 @@ def populate_registry() -> None:
     from .optimizers import create_adamw  # noqa
     from .optimizers import create_linear_schedule_with_warmup  # noqa
     from .tasks import create_behrt, clf_encoder  # noqa
+    from .registry import list_creator
 
 
 populate_registry()
@@ -50,10 +51,11 @@ def train(config_path: Path | None = None) -> None:
     # Setup the logger and pass it to the TrainingConfig
     training_cfg = config.training
     if config.logger is not None:
-        # update config
-        log.info("Updating Config")
-        flat_config = flatten_nested_dict(config_dict)
-        config.logger.log_hyperparams(flat_config)
+        for logger in config.logger:
+            # update config
+            log.info("Updating Config")
+            flat_config = flatten_nested_dict(config_dict)
+            logger.log_hyperparams(flat_config)
 
     training_dataset = config.model_and_dataset.training_dataset
     validation_dataset = config.model_and_dataset.validation_dataset

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -26,7 +26,7 @@ def populate_registry() -> None:
     """
     from .callbacks import create_learning_rate_monitor, create_model_checkpoint  # noqa
     from .embedders.BEHRT_embedders import create_behrt_embedder  # noqa
-    from .logger import WandbCreator, MLFlowCreator  # noqa
+    from .logger import create_mlflow_logger, create_wandb_logger  # noqa
     from .model_layers import create_encoder_layer, create_transformers_encoder  # noqa
     from .optimizers import create_adam  # noqa
     from .optimizers import create_adamw  # noqa
@@ -49,17 +49,11 @@ def train(config_path: Path | None = None) -> None:
 
     # Setup the logger and pass it to the TrainingConfig
     training_cfg = config.training
-
-    logger_factory = config.logger_factory
-    if logger_factory is not None:
-        logger = config.logger_factory.get_logger()  # type: ignore
-        training_cfg.trainer.logger = logger
-        training_cfg.trainer.Config.allow_mutation = False
-
+    if config.logger is not None:
         # update config
         log.info("Updating Config")
         flat_config = flatten_nested_dict(config_dict)
-        logger.log_hyperparams(flat_config)
+        config.logger.log_hyperparams(flat_config)
 
     training_dataset = config.model_and_dataset.training_dataset
     validation_dataset = config.model_and_dataset.validation_dataset

--- a/psycop/common/sequence_models/train.py
+++ b/psycop/common/sequence_models/train.py
@@ -49,8 +49,10 @@ def train(config_path: Path | None = None) -> None:
 
     # Setup the logger and pass it to the TrainingConfig
     training_cfg = config.training
-    if config.logger is not None:
-        logger = config.logger.get_logger()
+
+    logger_factory = config.logger_factory
+    if logger_factory is not None:
+        logger = config.logger_factory.get_logger()  # type: ignore
         training_cfg.trainer.logger = logger
         training_cfg.trainer.Config.allow_mutation = False
 
@@ -62,7 +64,6 @@ def train(config_path: Path | None = None) -> None:
     training_dataset = config.model_and_dataset.training_dataset
     validation_dataset = config.model_and_dataset.validation_dataset
     model = config.model_and_dataset.model
-    logger = config.logger.get_logger()
     trainer_kwargs = training_cfg.trainer.to_dict()
 
     # filter dataset

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -46,9 +46,9 @@ logging_interval = "epoch"
 
 
 [training.trainer.logger]
-@loggers = "wandb"
+@loggers = "mlflow"
 experiment_name = "pretrain_behrt"
-run_name = "martin-pretrain"
+run_name = "pretrain-2023-12-15"
 save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain/2023-12-15/"
 metric_prefix = ""
 

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -46,10 +46,11 @@ logging_interval = "epoch"
 
 
 [training.trainer.logger]
-@loggers = "mlflow"
+@loggers = "wandb"
 experiment_name = "pretrain_behrt"
 run_name = "martin-pretrain"
 save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain/2023-12-15/"
+metric_prefix = ""
 
 [model_and_dataset]
 

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -46,16 +46,10 @@ logging_interval = "epoch"
 
 
 [training.trainer.logger]
-@loggers = "wandb"
-name = null
-save_dir = "logs/"
-version = null
-offline = true
-dir = null
-id = null
-anonymous = null
-project = "psycop-sequence-models"
-checkpoint_name = null
+@loggers = "mlflow"
+experiment_name = "pretrain_behrt"
+run_name = "martin-pretrain"
+save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain/2023-12-15/"
 
 [model_and_dataset]
 

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -38,22 +38,20 @@ monitor = "val_loss"
 save_top_k = 2
 every_n_epochs = 1
 mode = "min"
-save_dir = ${training.trainer.logger.save_dir}
+save_dir = ${logger.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
 
-[training.trainer.logger]
+[logger]
 @loggers = "mlflow"
 experiment_name = "pretrain_behrt"
 run_name = "pretrain-2023-12-15"
-save_dir = "E:/shared_resources/sequence_models/BEHRT/
-metric_prefix = ""
+save_dir = "E:/shared_resources/sequence_models/BEHRT/"
 
 [model_and_dataset]
-
 [model_and_dataset.model]
 @tasks = "behrt"
 

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -28,6 +28,7 @@ accumulate_grad_batches = 1
 gradient_clip_val = null
 gradient_clip_algorithm = null
 default_root_dir = "logs/"
+logger=${logger.mlflow}
 
 [training.trainer.callbacks]
 @callbacks = "callback_list"
@@ -38,18 +39,19 @@ monitor = "val_loss"
 save_top_k = 2
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger_factory.save_dir}
+save_dir = ${logger.mlflow.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
 
-[logger_factory]
+[logger]
+[logger.mlflow]
 @loggers = "mlflow"
 experiment_name = "pretrain_behrt"
 run_name = "pretrain-2023-12-15"
-save_dir = "E:/shared_resources/sequence_models/BEHRT/"
+save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain_behrt/pretrain-2023-12-15/"
 
 [model_and_dataset]
 [model_and_dataset.model]

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -38,7 +38,7 @@ monitor = "val_loss"
 save_top_k = 2
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger.save_dir}
+save_dir = ${logger_factory.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -49,7 +49,7 @@ logging_interval = "epoch"
 @loggers = "mlflow"
 experiment_name = "pretrain_behrt"
 run_name = "pretrain-2023-12-15"
-save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain/2023-12-15/"
+save_dir = "E:/shared_resources/sequence_models/BEHRT/
 metric_prefix = ""
 
 [model_and_dataset]

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -45,7 +45,7 @@ save_dir = ${logger.save_dir}
 logging_interval = "epoch"
 
 
-[logger]
+[logger_factory]
 @loggers = "mlflow"
 experiment_name = "pretrain_behrt"
 run_name = "pretrain-2023-12-15"

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -45,9 +45,10 @@ save_dir = ${logger.mlflow.save_dir}
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
-
 [logger]
-[logger.mlflow]
+@utilities = "list_creator"
+
+[logger.*.mlflow]
 @loggers = "mlflow"
 experiment_name = "pretrain_behrt"
 run_name = "pretrain-2023-12-15"

--- a/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
@@ -49,7 +49,9 @@ logging_interval = "epoch"
 
 
 [logger]
-[logger.mlflow]
+@utilities = "list_creator"
+
+[logger.*.mlflow]
 @loggers = "wandb"
 experiment_name = "pretrain_mini_behrt"
 run_name = "mini_behrt"

--- a/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
@@ -41,19 +41,18 @@ monitor = "val_loss"
 save_top_k = 5
 every_n_epochs = 1
 mode = "min"
-save_dir = ${training.trainer.logger.save_dir}
+save_dir = ${logger.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
 
-[training.trainer.logger]
+[logger]
 @loggers = "wandb"
 experiment_name = "pretrain_mini_behrt"
 run_name = "mini_behrt"
 save_dir = "logs/"
-
 
 [model_and_dataset]
 [model_and_dataset.model]

--- a/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
@@ -41,14 +41,15 @@ monitor = "val_loss"
 save_top_k = 5
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger_factory.save_dir}
+save_dir = ${logger.mlflow.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
 logging_interval = "epoch"
 
 
-[logger_factory]
+[logger]
+[logger.mlflow]
 @loggers = "wandb"
 experiment_name = "pretrain_mini_behrt"
 run_name = "mini_behrt"

--- a/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
@@ -41,7 +41,7 @@ monitor = "val_loss"
 save_top_k = 5
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger.save_dir}
+save_dir = ${logger_factory.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"

--- a/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
@@ -50,15 +50,10 @@ logging_interval = "epoch"
 
 [training.trainer.logger]
 @loggers = "wandb"
-name = null
+experiment_name = "pretrain_mini_behrt"
+run_name = "mini_behrt"
 save_dir = "logs/"
-version = null
-offline = true
-dir = null
-id = null
-anonymous = null
-project = "psycop-sequence-models"
-checkpoint_name = null
+
 
 [model_and_dataset]
 [model_and_dataset.model]

--- a/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_mini_behrt.cfg
@@ -48,7 +48,7 @@ save_dir = ${logger.save_dir}
 logging_interval = "epoch"
 
 
-[logger]
+[logger_factory]
 @loggers = "wandb"
 experiment_name = "pretrain_mini_behrt"
 run_name = "mini_behrt"


### PR DESCRIPTION
For #560, I needed the path of the pretrained model. However, I think it is on your user account (ADMINKEN**) @KennethEnevoldsen.

So, wanted to run a new pretraining that saves to a dir on `E:/shared_resources`, and might as well add mlflow at the same time.

* Unified logger interfaces, to make it easier to change between them
* Added mlflow logger

Started a training, but failed because of the MLflow server being down. More info here: https://github.com/Aarhus-Psychiatry-Research/psycop-ml-ops/issues/54

Also fixes #562.