### PR TITLE
refactor: move min_n_visits filtering to PatientLoader

### DIFF
--- a/psycop/common/feature_generation/sequences/cohort_definer_to_prediction_times.py
+++ b/psycop/common/feature_generation/sequences/cohort_definer_to_prediction_times.py
@@ -121,8 +121,9 @@ class CohortToPredictionTimes:
 
 if __name__ == "__main__":
     patients = PatientLoader.get_split(
-        event_loaders=[DiagnosisLoader(min_n_visits=5)],
+        event_loaders=[DiagnosisLoader()],
         split=SplitName.TRAIN,
+        min_n_events=5,
     )
 
     prediction_times = CohortToPredictionTimes(

--- a/psycop/common/feature_generation/sequences/patient_slice_getter.py
+++ b/psycop/common/feature_generation/sequences/patient_slice_getter.py
@@ -23,6 +23,7 @@ class UnlabelledSliceCreator(BaseUnlabelledSliceCreator):
         split_name: Literal["train", "val", "test"],
         cohort_definer: CohortDefiner,
         event_loaders: Sequence[EventDfLoader],
+        min_n_events: int | None = None,
         load_fraction: float = 1.0,
     ):
         self.split_name = split_name
@@ -30,6 +31,7 @@ class UnlabelledSliceCreator(BaseUnlabelledSliceCreator):
         self.cohort_definer = cohort_definer
         self.event_loaders = event_loaders
         self.load_fraction = load_fraction
+        self.min_n_events = min_n_events
 
     def get_patient_slices(
         self,
@@ -37,6 +39,7 @@ class UnlabelledSliceCreator(BaseUnlabelledSliceCreator):
         patients = PatientLoader.get_split(
             event_loaders=self.event_loaders,
             split=SplitName(self.split_name),
+            min_n_events=self.min_n_events,
             fraction=self.load_fraction,
         )
 

--- a/psycop/common/feature_generation/sequences/test_event_dataframes_to_patient.py
+++ b/psycop/common/feature_generation/sequences/test_event_dataframes_to_patient.py
@@ -153,9 +153,7 @@ def test_passing_patient_colnames():
     )
 
     formatted_df = (
-        DiagnosisLoader(min_n_visits=None)
-        .preprocess_diagnosis_columns(df=df.lazy())
-        .collect()
+        DiagnosisLoader().preprocess_diagnosis_columns(df=df.lazy()).collect()
     )
 
     unpacked_with_source_subtype_column = EventDataFramesToPatientSlices(

--- a/psycop/common/feature_generation/sequences/test_patient_loaders.py
+++ b/psycop/common/feature_generation/sequences/test_patient_loaders.py
@@ -18,7 +18,7 @@ def test_diagnosis_preprocessing():
     """,
     )
 
-    formatted_df = DiagnosisLoader(min_n_visits=None).preprocess_diagnosis_columns(
+    formatted_df = DiagnosisLoader().preprocess_diagnosis_columns(
         df=df.lazy(),
     )
 

--- a/psycop/projects/sequence_models/pretrain.py
+++ b/psycop/projects/sequence_models/pretrain.py
@@ -19,12 +19,11 @@ from psycop.common.sequence_models.train import train
 
 @Registry.datasets.register("diagnosis_only_patient_slice_dataset")
 def create_patient_slice_dataset(
-    min_n_visits: int,
     split_name: str,
 ) -> PatientSliceDataset:
     train_patients = PatientLoader.get_split(
         event_loaders=[
-            DiagnosisLoader(min_n_visits=min_n_visits),
+            DiagnosisLoader(),
         ],
         split=SplitName(split_name),
     )


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->

Move filtering of patients by minimum number of events to the loading of patients, rather than the loading of events. Makes more semantic sense IMO.