### PR TITLE
feat: ready for pretraining

### DIFF
--- a/psycop/projects/sequence_models/pretrain.py
+++ b/psycop/projects/sequence_models/pretrain.py
@@ -6,29 +6,7 @@ project_path = Path(__file__).parents[3]
 print(project_path)
 sys.path.append(str(project_path))
 
-
-from psycop.common.feature_generation.loaders.raw.load_ids import SplitName
-from psycop.common.feature_generation.sequences.patient_loaders import (
-    DiagnosisLoader,
-    PatientLoader,
-)
-from psycop.common.sequence_models.dataset import PatientSliceDataset
-from psycop.common.sequence_models.registry import Registry
 from psycop.common.sequence_models.train import train
-
-
-@Registry.datasets.register("diagnosis_only_patient_slice_dataset")
-def create_patient_slice_dataset(
-    split_name: str,
-) -> PatientSliceDataset:
-    train_patients = PatientLoader.get_split(
-        event_loaders=[
-            DiagnosisLoader(),
-        ],
-        split=SplitName(split_name),
-    )
-    return PatientSliceDataset([p.as_slice() for p in train_patients])
-
 
 if __name__ == "__main__":
     config_path = Path(__file__).parent / "pretrain_behrt.cfg"

--- a/psycop/projects/sequence_models/pretrain_behrt.cfg
+++ b/psycop/projects/sequence_models/pretrain_behrt.cfg
@@ -28,7 +28,7 @@ accumulate_grad_batches = 1
 gradient_clip_val = null
 gradient_clip_algorithm = null
 default_root_dir = "logs/"
-logger=${logger.mlflow}
+logger=${logger.*.mlflow}
 
 [training.trainer.callbacks]
 @callbacks = "callback_list"
@@ -39,7 +39,7 @@ monitor = "val_loss"
 save_top_k = 2
 every_n_epochs = 1
 mode = "min"
-save_dir = ${logger.mlflow.save_dir}
+save_dir = ${logger.*.mlflow.save_dir}
 
 [training.trainer.callbacks.*.learning_rate_monitor]
 @callbacks = "learning_rate_monitor"
@@ -51,8 +51,8 @@ logging_interval = "epoch"
 [logger.*.mlflow]
 @loggers = "mlflow"
 experiment_name = "pretrain_behrt"
-run_name = "pretrain-2023-12-15"
-save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain_behrt/pretrain-2023-12-15/"
+run_name = "pretrain-test"
+save_dir = "E:/shared_resources/sequence_models/BEHRT/pretrain_behrt/pretrain-test/"
 
 [model_and_dataset]
 [model_and_dataset.model]
@@ -88,6 +88,7 @@ layer_norm_eps = 1e-12
 norm_first = false
 
 [cohort_definer]
+[cohort_definer.cohort]
 @cohorts = "t2d"
 
 [event_loader]
@@ -95,16 +96,15 @@ norm_first = false
 
 [event_loader.*.diagnoses]
 @event_loaders = "diagnoses"
-min_n_visits = 5
 
 [model_and_dataset.training_dataset]
 @datasets = "unlabelled_slice_creator"
-cohort_definer = ${cohort_definer}
+cohort_definer = ${cohort_definer.cohort}
 event_loaders = ${event_loader}
 split_name = "train"
 
 [model_and_dataset.validation_dataset]
 @datasets = "unlabelled_slice_creator"
-cohort_definer = ${cohort_definer}
+cohort_definer = ${cohort_definer.cohort}
 event_loaders = ${event_loader}
 split_name = "val"


### PR DESCRIPTION
Importing the Registry worked in a sample of other files in the repo, so there must be some circular importation going on here.

However, we don't need the registry import anymore due to decomposition of the dataset. The current pretrain runs on Ovartaci, so I think it's OK for now.

Fixes #582.
