### PR TITLE
deps: add connectorx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,5 @@ timeseriesflattener==1.8.0
 wandb==0.15.4
 wasabi==0.9.1
 xgboost==1.7.3
+connectorx==0.3.2
 


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
Adds `connectorx` as a dependency. Required to use polars for reading from a SQL database. This will allows us to read from SQL as e.g. a lazyframe instead of a pandas dataframe which could be a significant speed boost