### PR TITLE
faster generation using slots

### DIFF
--- a/psycop/common/data_structures/patient.py
+++ b/psycop/common/data_structures/patient.py
@@ -129,7 +129,7 @@ class Patient:
         return prediction_sequences
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PatientSlice:
     patient: Patient
     temporal_events: Sequence[TemporalEvent]

--- a/psycop/common/data_structures/temporal_event.py
+++ b/psycop/common/data_structures/temporal_event.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     import datetime as dt
 
 
-@dataclass
+@dataclass(slots=True)
 class TemporalEvent:
     """
     Attributes:

--- a/psycop/common/sequence_models/embedders/BEHRT_embedders.py
+++ b/psycop/common/sequence_models/embedders/BEHRT_embedders.py
@@ -245,7 +245,7 @@ class BEHRTEmbedder(nn.Module, PatientSliceEmbedder):
                     value=mapped_value,
                 )
                 for e in filtered_events
-                if (mapped_value := self.map_icd10_to_caliber(e.value)) is not None
+                if (mapped_value := self.map_icd10_to_caliber(e.value)) is not None  # type: ignore
             ]
 
             _patient_slices.append(PatientSlice(p.patient, temporal_events))

--- a/psycop/common/sequence_models/embedders/BEHRT_embedders.py
+++ b/psycop/common/sequence_models/embedders/BEHRT_embedders.py
@@ -7,7 +7,6 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from functools import lru_cache
 
 import numpy as np
 import torch
@@ -209,7 +208,6 @@ class BEHRTEmbedder(nn.Module, PatientSliceEmbedder):
     def is_A_diagnosis(self, event: TemporalEvent) -> bool:
         return event.source_type == "diagnosis" and event.source_subtype == "A"
 
-    @lru_cache
     def map_icd10_to_caliber(
         self,
         diagnosis_code: str,


### PR DESCRIPTION
This should help creating instances faster in behrtembedder.reformat. Dataclass creation is by far the most time consuming thing. Second is mapicd which takes up 16% of the time.