### PR TITLE
fix: replace disallowed symbols in config before logging to mlflow

### DIFF
--- a/psycop/common/global_utils/config_utils.py
+++ b/psycop/common/global_utils/config_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableMapping
-from typing import Any, Iterable
+from typing import Any
 
 
 def flatten_nested_dict(
@@ -34,11 +34,13 @@ def flatten_nested_dict(
 
 
 def replace_symbols_in_dict_keys(
-    d: dict[str, Any], symbol2replacement: dict[str, str]
-):
+    d: dict[str, Any],
+    symbol2replacement: dict[str, str],
+) -> dict[str, Any]:
     new_dict = {}
     for key, value in d.items():
+        new_key = key
         for symbol, replacement in symbol2replacement.items():
-            key = key.replace(symbol, replacement)
-        new_dict[key] = value
+            new_key = new_key.replace(symbol, replacement)
+        new_dict[new_key] = value
     return new_dict

--- a/psycop/common/global_utils/config_utils.py
+++ b/psycop/common/global_utils/config_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableMapping
-from typing import Any
+from typing import Any, Iterable
 
 
 def flatten_nested_dict(
@@ -31,3 +31,14 @@ def flatten_nested_dict(
         else:
             items.append((new_key, v))
     return dict(items)
+
+
+def replace_symbols_in_dict_keys(
+    d: dict[str, Any], symbol2replacement: dict[str, str]
+):
+    new_dict = {}
+    for key, value in d.items():
+        for symbol, replacement in symbol2replacement.items():
+            key = key.replace(symbol, replacement)
+        new_dict[key] = value
+    return new_dict

--- a/psycop/common/model_training_v2/loggers/mlflow_logger.py
+++ b/psycop/common/model_training_v2/loggers/mlflow_logger.py
@@ -65,7 +65,7 @@ class MLFlowLogger(BaselineLogger):
     def log_config(self, config: dict[str, Any]):
         config = flatten_nested_dict(config)
         clean_config = replace_symbols_in_dict_keys(
-            d=config, symbol2replacement={"@": "", "*": "_"}
+            d=config,
+            symbol2replacement={"@": "", "*": "_"},
         )
         mlflow.log_params(clean_config)
-

--- a/psycop/common/model_training_v2/loggers/mlflow_logger.py
+++ b/psycop/common/model_training_v2/loggers/mlflow_logger.py
@@ -4,7 +4,10 @@ from typing import Any
 
 import mlflow
 
-from psycop.common.global_utils.config_utils import flatten_nested_dict
+from psycop.common.global_utils.config_utils import (
+    flatten_nested_dict,
+    replace_symbols_in_dict_keys,
+)
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
 from psycop.common.model_training_v2.loggers.base_logger import BaselineLogger
 from psycop.common.model_training_v2.trainer.task.base_metric import CalculatedMetric
@@ -18,8 +21,8 @@ class MLFlowLogger(BaselineLogger):
         tracking_uri: str = "http://exrhel0371.it.rm.dk:5050",
     ) -> None:
         mlflow.set_tracking_uri(tracking_uri)
-        mlflow.set_experiment(experiment_name=experiment_name)
-
+        self.mlflow_experiment = mlflow.set_experiment(experiment_name=experiment_name)
+        self.experiment_id = self.mlflow_experiment.experiment_id
         self._log_str = ""
 
     def _append_log_str(self, prefix: str, message: str):
@@ -32,7 +35,7 @@ class MLFlowLogger(BaselineLogger):
 
         self._append_log_str(prefix, message)
 
-        tmp_log_path = Path("tmp_log.txt")
+        tmp_log_path = Path(f"{self.experiment_id}-tmp_log.txt")
 
         # Write log temporarily to disk
         with tmp_log_path.open("w") as f:
@@ -61,5 +64,8 @@ class MLFlowLogger(BaselineLogger):
 
     def log_config(self, config: dict[str, Any]):
         config = flatten_nested_dict(config)
-        for k, v in config.items():
-            mlflow.log_param(key=k, value=v)
+        clean_config = replace_symbols_in_dict_keys(
+            d=config, symbol2replacement={"@": "", "*": "_"}
+        )
+        mlflow.log_params(clean_config)
+


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
Mlflow does not allow @ and * when logging params. Changed the values to "" and "_" instead. Added the name of the run-id to tmp path to avoid potential conflicts during parallel runs. 

Merged, but feel free to post review