### PR TITLE
feat: joint id loader

### DIFF
--- a/psycop/common/feature_generation/application_modules/save_dataset_to_disk.py
+++ b/psycop/common/feature_generation/application_modules/save_dataset_to_disk.py
@@ -15,7 +15,7 @@ from psycop.common.feature_generation.application_modules.wandb_utils import (
 )
 from psycop.common.feature_generation.loaders.raw.load_ids import (
     SplitName,
-    load_original_ids,
+    load_stratified_by_outcome_split_ids,
 )
 from psycop.common.feature_generation.utils import write_df_to_file
 
@@ -79,7 +79,7 @@ def filter_by_split_ids(
 
 def get_split_id_df(split_name: SplitName) -> pd.DataFrame:
     """Get a dataframe with the splits ids."""
-    split_id_df = load_original_ids(
+    split_id_df = load_stratified_by_outcome_split_ids(
         split=split_name,
     )
 

--- a/psycop/common/feature_generation/application_modules/save_dataset_to_disk.py
+++ b/psycop/common/feature_generation/application_modules/save_dataset_to_disk.py
@@ -13,7 +13,10 @@ from psycop.common.feature_generation.application_modules.project_setup import (
 from psycop.common.feature_generation.application_modules.wandb_utils import (
     wandb_alert_on_exception,
 )
-from psycop.common.feature_generation.loaders.raw.load_ids import SplitName, load_ids
+from psycop.common.feature_generation.loaders.raw.load_ids import (
+    SplitName,
+    load_original_ids,
+)
 from psycop.common.feature_generation.utils import write_df_to_file
 
 log = logging.getLogger(__name__)
@@ -76,7 +79,7 @@ def filter_by_split_ids(
 
 def get_split_id_df(split_name: SplitName) -> pd.DataFrame:
     """Get a dataframe with the splits ids."""
-    split_id_df = load_ids(
+    split_id_df = load_original_ids(
         split=split_name,
     )
 

--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
 from psycop.common.model_training_v2.trainer.data.data_filters.geographical_split.make_geographical_split import (
@@ -23,7 +23,8 @@ class SplitName(Enum):
 
 
 def load_stratified_by_outcome_split_ids(
-    split: SplitName, n_rows: int | None = None
+    split: SplitName,
+    n_rows: int | None = None,
 ) -> pd.DataFrame:
     """Loads ids for a given split based on the original data split.
 
@@ -43,7 +44,10 @@ def load_stratified_by_outcome_split_ids(
     return df.reset_index(drop=True)
 
 
-def load_stratified_by_region_split_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
+def load_stratified_by_region_split_ids(
+    split: SplitName,
+    n_rows: int | None = None,
+) -> pd.DataFrame:
     """Loads ids for a given split using the region-based split.
 
     Args:

--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
+from psycop.common.model_training_v2.trainer.data.data_filters.geographical_split.make_geographical_split import (
+    get_regional_split_df,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
+
+import polars as pl
 
 
 class SplitName(Enum):
@@ -17,11 +22,11 @@ class SplitName(Enum):
     TEST = "test"
 
 
-def load_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
-    """Loads ids for a given split.
+def load_original_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
+    """Loads ids for a given split based on the original data split.
 
     Args:
-        split (str): Which split to load IDs from. Takes either "train", "test" or "val". # noqa: DAR102
+        split: Which split to load IDs from. Takes either "train", "test" or "val".
         n_rows: Number of rows to return. Defaults to None.
 
     Returns:
@@ -34,3 +39,47 @@ def load_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
     df = sql_load(sql, database="USR_PS_FORSK", n_rows=n_rows)
 
     return df.reset_index(drop=True)
+
+
+def load_region_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
+    """Loads ids for a given split using the region-based split.
+
+    Args:
+        split: Which split to load IDs from. Takes either "train", "test" or "val".
+        n_rows: Number of rows to return. Defaults to None.
+
+    Returns:
+        pd.DataFrame: Only dw_ek_borger column with ids
+    """
+    split_df = (
+        get_regional_split_df()
+        .filter(pl.col("split") == split.value)
+        .select("dw_ek_borger")
+        .collect()
+    )
+    if n_rows is not None:
+        split_df = split_df.head(n_rows)
+    return split_df.to_pandas()
+
+
+def load_ids(
+    split_type: Literal["original", "geographical"],
+    split_name: SplitName,
+    n_rows: int | None = None,
+) -> pd.DataFrame:
+    """Loads ids for a given split.
+
+    Args:
+        split_type: Which split to load IDs from. Takes either "original" or "geographical".
+        split: Which split to load IDs from. Takes either "train", "test" or "val".
+        n_rows: Number of rows to return. Defaults to None.
+
+    Returns:
+        pd.DataFrame: Only dw_ek_borger column with ids
+    """
+    if split_type == "original":
+        return load_original_ids(split=split_name, n_rows=n_rows)
+    elif split_type == "geographical":
+        return load_region_ids(split=split_name, n_rows=n_rows)
+    else:
+        raise ValueError(f"split_type {split_type} is not allowed")

--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -22,7 +22,9 @@ class SplitName(Enum):
     TEST = "test"
 
 
-def load_original_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
+def load_stratified_by_outcome_split_ids(
+    split: SplitName, n_rows: int | None = None
+) -> pd.DataFrame:
     """Loads ids for a given split based on the original data split.
 
     Args:
@@ -41,7 +43,7 @@ def load_original_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFra
     return df.reset_index(drop=True)
 
 
-def load_region_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
+def load_stratified_by_region_split_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame:
     """Loads ids for a given split using the region-based split.
 
     Args:
@@ -60,25 +62,3 @@ def load_region_ids(split: SplitName, n_rows: int | None = None) -> pd.DataFrame
     if n_rows is not None:
         split_df = split_df.head(n_rows)
     return split_df.to_pandas()
-
-
-def load_ids(
-    split_type: Literal["original", "geographical"],
-    split_name: SplitName,
-    n_rows: int | None = None,
-) -> pd.DataFrame:
-    """Loads ids for a given split.
-
-    Args:
-        split_type: Which split to load IDs from. Takes either "original" or "geographical".
-        split_name: Which split to load IDs from. Takes either "train", "test" or "val".
-        n_rows: Number of rows to return. Defaults to None.
-
-    Returns:
-        pd.DataFrame: Only dw_ek_borger column with ids
-    """
-    if split_type == "original":
-        return load_original_ids(split=split_name, n_rows=n_rows)
-    if split_type == "geographical":
-        return load_region_ids(split=split_name, n_rows=n_rows)
-    raise ValueError(f"split_type {split_type} is not allowed")

--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -71,7 +71,7 @@ def load_ids(
 
     Args:
         split_type: Which split to load IDs from. Takes either "original" or "geographical".
-        split: Which split to load IDs from. Takes either "train", "test" or "val".
+        split_name: Which split to load IDs from. Takes either "train", "test" or "val".
         n_rows: Number of rows to return. Defaults to None.
 
     Returns:
@@ -79,7 +79,6 @@ def load_ids(
     """
     if split_type == "original":
         return load_original_ids(split=split_name, n_rows=n_rows)
-    elif split_type == "geographical":
+    if split_type == "geographical":
         return load_region_ids(split=split_name, n_rows=n_rows)
-    else:
-        raise ValueError(f"split_type {split_type} is not allowed")
+    raise ValueError(f"split_type {split_type} is not allowed")

--- a/psycop/common/feature_generation/loaders/raw/load_text.py
+++ b/psycop/common/feature_generation/loaders/raw/load_text.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from psycop.common.feature_generation.application_modules.save_dataset_to_disk import (
     filter_by_split_ids,
-    get_split_id_df,
 )
 from psycop.common.feature_generation.loaders.raw.load_ids import load_ids
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
@@ -159,6 +158,7 @@ def load_text_split(
     Args:
         text_sfi_names (Union[str, list[str]]): Which sfi types to load. See `get_all_valid_text_sfi_names()` for valid sfi types.
         split_name (Literal["train", "val"], optional): Which splis to include. Defaults to Literal["train", "val"].
+        split_type (Literal["original", "geographical"], optional): Which split to load IDs from. Defaults to "original".
         include_sfi_name (bool, optional): Whether to include column with sfi name ("overskrift"). Defaults to False.
         n_rows (Optional[int, None], optional): Number of rows to load. Defaults to None.
 

--- a/psycop/common/feature_generation/loaders/raw/load_text.py
+++ b/psycop/common/feature_generation/loaders/raw/load_text.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 
 from functools import partial
 from multiprocessing import Pool
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Callable
 
 import pandas as pd
 
 from psycop.common.feature_generation.application_modules.save_dataset_to_disk import (
     filter_by_split_ids,
 )
-from psycop.common.feature_generation.loaders.raw.load_ids import load_stratified_by_outcome_split_ids
+from psycop.common.feature_generation.loaders.raw.load_ids import (
+    load_stratified_by_outcome_split_ids,
+)
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
 from psycop.common.feature_generation.utils import data_loaders
 

--- a/psycop/common/feature_generation/loaders/raw/load_text.py
+++ b/psycop/common/feature_generation/loaders/raw/load_text.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from functools import partial
 from multiprocessing import Pool
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 
@@ -11,6 +11,7 @@ from psycop.common.feature_generation.application_modules.save_dataset_to_disk i
     filter_by_split_ids,
     get_split_id_df,
 )
+from psycop.common.feature_generation.loaders.raw.load_ids import load_ids
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
 from psycop.common.feature_generation.utils import data_loaders
 
@@ -149,6 +150,7 @@ def load_text_sfis(
 def load_text_split(
     text_sfi_names: str | Iterable[str],
     split_name: Sequence[SplitName],
+    split_type: Literal["original", "geographical"] = "original",
     include_sfi_name: bool = False,
     n_rows: int | None = None,
 ) -> pd.DataFrame:
@@ -171,7 +173,7 @@ def load_text_split(
     )
 
     split_id_df = pd.concat(
-        [get_split_id_df(split_name=split) for split in split_name],
+        [load_ids(split_type=split_type, split_name=split) for split in split_name],
     )
 
     text_split_df = filter_by_split_ids(

--- a/psycop/common/feature_generation/sequences/patient_loader.py
+++ b/psycop/common/feature_generation/sequences/patient_loader.py
@@ -8,7 +8,7 @@ from psycop.common.data_structures.patient import Patient
 from psycop.common.feature_generation.loaders.raw.load_demographic import birthdays
 from psycop.common.feature_generation.loaders.raw.load_ids import (
     SplitName,
-    load_original_ids,
+    load_stratified_by_outcome_split_ids,
 )
 from psycop.common.feature_generation.sequences.event_loader import (
     DiagnosisLoader,
@@ -46,7 +46,7 @@ class PatientLoader:
     ) -> Sequence[Patient]:
         event_data = pl.concat([loader.load_events() for loader in event_loaders])
         split_ids = (
-            pl.from_pandas(load_original_ids(split=split))
+            pl.from_pandas(load_stratified_by_outcome_split_ids(split=split))
             .sample(fraction=fraction)
             .lazy()
         )

--- a/psycop/common/feature_generation/sequences/patient_loader.py
+++ b/psycop/common/feature_generation/sequences/patient_loader.py
@@ -6,7 +6,10 @@ import polars as pl
 
 from psycop.common.data_structures.patient import Patient
 from psycop.common.feature_generation.loaders.raw.load_demographic import birthdays
-from psycop.common.feature_generation.loaders.raw.load_ids import SplitName, load_ids
+from psycop.common.feature_generation.loaders.raw.load_ids import (
+    SplitName,
+    load_original_ids,
+)
 from psycop.common.feature_generation.sequences.event_loader import (
     DiagnosisLoader,
     EventLoader,
@@ -43,7 +46,9 @@ class PatientLoader:
     ) -> Sequence[Patient]:
         event_data = pl.concat([loader.load_events() for loader in event_loaders])
         split_ids = (
-            pl.from_pandas(load_ids(split=split)).sample(fraction=fraction).lazy()
+            pl.from_pandas(load_original_ids(split=split))
+            .sample(fraction=fraction)
+            .lazy()
         )
 
         events_from_train = split_ids.join(event_data, on="dw_ek_borger", how="left")

--- a/psycop/common/model_training_v2/trainer/data/data_filters/geographical_split/make_geographical_split.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/geographical_split/make_geographical_split.py
@@ -92,6 +92,9 @@ def add_shak_to_region_mapping(
 
 
 def get_regional_split_df() -> pl.LazyFrame:
+    """Return a dataframe with the region at which each patient first had
+    a contact. If a patient had contacts at multiple regions, the timestamp
+    of the first contact at a different region is also included."""
     shak_to_location_df = load_shak_to_location_mapping()
 
     visits = pl.from_pandas(physical_visits(shak_code=6600, return_shak_location=True))
@@ -122,10 +125,18 @@ def get_regional_split_df() -> pl.LazyFrame:
         first_visit_at_first_region,
         first_visit_at_second_region,
     )
+    # add indicator for which split each patient belongs to
+    geographical_split_df = geographical_split_df.with_columns(
+        pl.when(pl.col("region") == "øst")
+        .then("train")
+        .when(pl.col("region") == "vest")
+        .then("val")
+        .otherwise("test")
+        .alias("split")
+    )
+
     return geographical_split_df.select(
-        "dw_ek_borger",
-        "region",
-        "first_regional_move_timestamp",
+        "dw_ek_borger", "region", "first_regional_move_timestamp", "split"
     ).lazy()
 
 

--- a/psycop/common/model_training_v2/trainer/data/data_filters/geographical_split/make_geographical_split.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/geographical_split/make_geographical_split.py
@@ -132,11 +132,14 @@ def get_regional_split_df() -> pl.LazyFrame:
         .when(pl.col("region") == "vest")
         .then("val")
         .otherwise("test")
-        .alias("split")
+        .alias("split"),
     )
 
     return geographical_split_df.select(
-        "dw_ek_borger", "region", "first_regional_move_timestamp", "split"
+        "dw_ek_borger",
+        "region",
+        "first_regional_move_timestamp",
+        "split",
     ).lazy()
 
 

--- a/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
@@ -48,7 +48,9 @@ class RegionalFilter(BaselineDataFilter):
         if regional_move_df is None:
             self.filtered_regional_move_df = self._filter_regional_move_df_by_regions(
                 get_regional_split_df().select(
-                    "dw_ek_borger", "region", "first_regional_move_timestamp"
+                    "dw_ek_borger",
+                    "region",
+                    "first_regional_move_timestamp",
                 ),
             )
         else:

--- a/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
@@ -47,7 +47,9 @@ class RegionalFilter(BaselineDataFilter):
 
         if regional_move_df is None:
             self.filtered_regional_move_df = self._filter_regional_move_df_by_regions(
-                get_regional_split_df(),
+                get_regional_split_df().select(
+                    "dw_ek_borger", "region", "first_regional_move_timestamp"
+                ),
             )
         else:
             self.filtered_regional_move_df = self._filter_regional_move_df_by_regions(

--- a/psycop/common/model_training_v2/trainer/data/data_filters/original_ids.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/original_ids.py
@@ -5,7 +5,7 @@ import polars as pl
 
 from psycop.common.feature_generation.loaders.raw.load_ids import (
     SplitName,
-    load_original_ids,
+    load_stratified_by_outcome_split_ids,
 )
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
 from psycop.common.model_training_v2.trainer.base_dataloader import BaselineDataLoader
@@ -65,5 +65,8 @@ class IDDataFilter:
                         f"Splitname {split_name} is not allowed, try from ['train', 'test', 'val']",
                     )
         return pl.concat(
-            [pl.from_pandas(load_original_ids(split)) for split in split_names],
+            [
+                pl.from_pandas(load_stratified_by_outcome_split_ids(split))
+                for split in split_names
+            ],
         ).get_column("dw_ek_borger")

--- a/psycop/common/model_training_v2/trainer/data/data_filters/original_ids.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/original_ids.py
@@ -3,7 +3,10 @@ from typing import Literal
 
 import polars as pl
 
-from psycop.common.feature_generation.loaders.raw.load_ids import SplitName, load_ids
+from psycop.common.feature_generation.loaders.raw.load_ids import (
+    SplitName,
+    load_original_ids,
+)
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
 from psycop.common.model_training_v2.trainer.base_dataloader import BaselineDataLoader
 
@@ -62,5 +65,5 @@ class IDDataFilter:
                         f"Splitname {split_name} is not allowed, try from ['train', 'test', 'val']",
                     )
         return pl.concat(
-            [pl.from_pandas(load_ids(split)) for split in split_names],
+            [pl.from_pandas(load_original_ids(split)) for split in split_names],
         ).get_column("dw_ek_borger")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ exclude = [
   "**/.*venv*",
   ".tox",
   "build",
+  # don't check files that import synthcity as it is not installed on the main environment
   "psycop/projects/scz_bp/model_training/estimator_steps/synth_data_augmentation.py",
   "psycop/projects/scz_bp/model_training/estimator_steps/test_synth_data_augmentation.py",
 ]


### PR DESCRIPTION
Adds a `split` column to the regional split dataframe for easy integration with other loaders. Added a function for loading either the original splits or the regional splits. 