### PR TITLE
feat: ValidatedFrame when we need to return frames

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,7 +48,6 @@
             },
             "dependsOn": [
                 "Lint",
-                "Merge main"
             ]
         },
         {
@@ -63,7 +62,6 @@
             },
             "dependsOn": [
                 "Lint",
-                "Merge main"
             ]
         }
     ]

--- a/psycop/common/model_training_v2/trainer/data/dataloaders.py
+++ b/psycop/common/model_training_v2/trainer/data/dataloaders.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import polars as pl
-from functionalpy import Seq
+from iterpy import Iter
 
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
 from psycop.common.model_training_v2.trainer.base_dataloader import BaselineDataLoader
@@ -31,7 +31,10 @@ class ParquetVerticalConcatenator(BaselineDataLoader):
 
         if validate_on_init:
             missing_paths = (
-                Seq(self.dataset_paths).map(self._check_path_exists).flatten().to_list()
+                Iter(self.dataset_paths)
+                .map(self._check_path_exists)
+                .flatten()
+                .to_list()
             )
             if missing_paths:
                 raise MissingPathError(

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import polars as pl
-from functionalpy import Seq
+from iterpy import Iter
 from polars import LazyFrame
 
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
@@ -83,7 +83,7 @@ class ColumnPrefixExpectation(PresplitStep):
         *args: list[str | int],
     ):
         self.column_expectations = (
-            Seq(args)
+            Iter(args)
             .map(
                 lambda x: ColumnCountExpectation.from_list(x),
             )
@@ -94,7 +94,7 @@ class ColumnPrefixExpectation(PresplitStep):
         df = input_df.fetch(1) if isinstance(input_df, LazyFrame) else input_df  # type: ignore
 
         errors = (
-            Seq(self.column_expectations)
+            Iter(self.column_expectations)
             .map(
                 lambda expectation: self._column_count_as_expected(
                     expectation=expectation,

--- a/psycop/common/types/test_validated_frame.py
+++ b/psycop/common/types/test_validated_frame.py
@@ -1,0 +1,59 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import polars as pl
+import pytest
+
+from ..test_utils.str_to_df import str_to_pl_df
+from .validated_frame import (
+    CombinedFrameValidationError,
+    ValidatedFrame,
+)
+from .validator_rules import ColumnTypeRule, ValidatorRule
+
+
+@dataclass(frozen=True)
+class FakeColnameValidatedFrame(ValidatedFrame[pl.DataFrame]):
+    frame: pl.DataFrame
+    test_col_name: str = "col_name"
+
+
+def test_col_name_validation():
+    df = str_to_pl_df(
+        """test_col_name,
+                      1,
+""",
+    )
+
+    with pytest.raises(CombinedFrameValidationError, match=".*missing.*"):
+        FakeColnameValidatedFrame(frame=df)
+
+
+def test_type_validation():
+    df = str_to_pl_df(
+        """test_col_name,
+                      1,
+""",
+    )
+
+    @dataclass(frozen=True)
+    class FakeTypeValidatedFrame(ValidatedFrame[pl.DataFrame]):
+        frame: pl.DataFrame
+        test_col_name: str = "test_col_name"
+        test_col_rules: Sequence[ValidatorRule] = [ColumnTypeRule(pl.Int64)]
+
+    with pytest.raises(CombinedFrameValidationError, match=".*type.*"):
+        FakeTypeValidatedFrame(frame=df)
+
+
+def test_rules_without_columns_error():
+    @dataclass(frozen=True)
+    class FakeFrameWithRulesWithoutColumns(ValidatedFrame[pl.DataFrame]):
+        frame: pl.DataFrame
+        test_col_rules: Sequence[ValidatorRule] = (ColumnTypeRule(pl.Int64),)
+
+    with pytest.raises(
+        CombinedFrameValidationError,
+        match=".*missing from the frame.*",
+    ):
+        FakeFrameWithRulesWithoutColumns(frame=pl.DataFrame())

--- a/psycop/common/types/test_validated_frame.py
+++ b/psycop/common/types/test_validated_frame.py
@@ -31,7 +31,7 @@ def test_col_name_validation():
 
 def test_type_validation():
     df = str_to_pl_df(
-        """test_col_name,
+        """test,
                       1,
 """,
     )
@@ -39,8 +39,8 @@ def test_type_validation():
     @dataclass(frozen=True)
     class FakeTypeValidatedFrame(ValidatedFrame[pl.DataFrame]):
         frame: pl.DataFrame
-        test_col_name: str = "test_col_name"
-        test_col_rules: Sequence[ValidatorRule] = [ColumnTypeRule(pl.Int64)]
+        test_col_name: str = "test"
+        test_col_rules: Sequence[ValidatorRule] = (ColumnTypeRule(pl.Utf8),)
 
     with pytest.raises(CombinedFrameValidationError, match=".*type.*"):
         FakeTypeValidatedFrame(frame=df)

--- a/psycop/common/types/validated_frame.py
+++ b/psycop/common/types/validated_frame.py
@@ -1,0 +1,89 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, TypeVar
+
+import polars as pl
+from iterpy import Iter
+
+from psycop.common.types.validator_rules import (
+    ColumnExistsRule,
+    ColumnInfo,
+    ValidatorRule,
+)
+
+from ..model_training_v2.trainer.preprocessing.steps.column_validator import (
+    MissingColumnError,
+)
+from .polarsframe import PolarsFrameGeneric
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class CombinedFrameValidationError(BaseException):
+    error: str
+
+
+@dataclass(frozen=True)
+class ValidatedFrame(Generic[PolarsFrameGeneric]):
+    """Validates a PolarsFrameGeneric based on the rules specified in the dataclass.
+
+    It dynamically applies rules based on the attributes, where any attribute ending in:
+    * '_col_name' is checked to be a column in the frame
+    * '_col_rules' consists of rules for that column, and are checked. E.g. 'test_col_rules' will be applied to the column 'test'.
+    """
+
+    frame: PolarsFrameGeneric
+
+    def _get_single_column_information(self, col_name_attr: str) -> ColumnInfo:
+        try:
+            rules: Sequence[ValidatorRule] = [
+                *getattr(self, col_name_attr.replace("_col_name", "_col_rules")),
+                ColumnExistsRule(),
+            ]
+        except AttributeError:
+            rules = [ColumnExistsRule()]
+
+        return ColumnInfo(
+            attr=col_name_attr,
+            name=getattr(self, f"{col_name_attr}"),
+            rules=rules,
+        )
+
+    def _get_column_infos(self) -> Iter[ColumnInfo]:
+        return (
+            Iter(vars(self))
+            .filter(lambda attr: "_col_name" in attr)
+            .map(lambda col_name: self._get_single_column_information(col_name))
+        )
+
+    def __post_init__(self):
+        validation_errors = (
+            Iter(
+                [c_info.check_rules(self.frame) for c_info in self._get_column_infos()],
+            )
+            .flatten()
+            .map(lambda error: error.get_error_string())
+            .to_list()
+        )
+
+        rules_without_columns = (
+            Iter(vars(self))
+            .filter(lambda attr: "_col_rules" in attr)
+            .map(
+                lambda col_rule_attr: col_rule_attr.replace("_col_rules", ""),
+            )
+            .filter(lambda col_name: col_name not in self.frame.columns)
+            .map(
+                lambda col_name: f"- Attribute '{col_name}_col_rules' specifies rules, but column '{col_name}' is missing from the frame.",
+            )
+            .to_list()
+        )
+
+        if validation_errors or rules_without_columns:
+            validation_error_string = "\n".join(
+                [*validation_errors, *rules_without_columns],
+            )
+            raise CombinedFrameValidationError(
+                f"Dataframe did not pass validation. Errors:\n{validation_error_string}",
+            )

--- a/psycop/common/types/validated_frame.py
+++ b/psycop/common/types/validated_frame.py
@@ -1,6 +1,5 @@
-from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from iterpy import Iter
 
@@ -11,6 +10,9 @@ from psycop.common.types.validator_rules import (
 )
 
 from .polarsframe import PolarsFrameGeneric
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 T = TypeVar("T")
 

--- a/psycop/common/types/validated_frame.py
+++ b/psycop/common/types/validated_frame.py
@@ -1,8 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Generic, TypeVar
 
-import polars as pl
 from iterpy import Iter
 
 from psycop.common.types.validator_rules import (
@@ -11,9 +10,6 @@ from psycop.common.types.validator_rules import (
     ValidatorRule,
 )
 
-from ..model_training_v2.trainer.preprocessing.steps.column_validator import (
-    MissingColumnError,
-)
 from .polarsframe import PolarsFrameGeneric
 
 T = TypeVar("T")

--- a/psycop/common/types/validator_rules.py
+++ b/psycop/common/types/validator_rules.py
@@ -1,0 +1,103 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+import polars as pl
+from iterpy import Iter
+
+from .polarsframe import PolarsFrame
+
+
+class FrameValidationError(Protocol):
+    def get_error_string(self) -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class ColumnInfo:
+    attr: str
+    name: str
+    rules: Sequence["ValidatorRule"]
+
+    @property
+    def specification_string(self) -> str:
+        return f"Attr '{self.attr}' specifies '{self.name}'"
+
+    def check_rules(
+        self,
+        frame: PolarsFrame,
+    ) -> Sequence["FrameValidationError"]:
+        return (
+            Iter(
+                [rule(self, frame) for rule in self.rules if rule(self, frame)],
+            )
+            .flatten()
+            .to_list()
+        )
+
+
+class ValidatorRule(Protocol):
+    def __call__(
+        self,
+        column_info: ColumnInfo,
+        frame: PolarsFrame,
+    ) -> Sequence[FrameValidationError]:
+        ...
+
+
+@dataclass(frozen=True)
+class ColumnMissingError(FrameValidationError):
+    column: ColumnInfo
+
+    def get_error_string(self) -> str:
+        return f"{self.column.specification_string}. Column is missing from frame."
+
+
+class ColumnExistsRule(ValidatorRule):
+    def __call__(
+        self,
+        column_info: ColumnInfo,
+        frame: PolarsFrame,
+    ) -> Sequence[ColumnMissingError]:
+        if column_info.name not in frame.columns:
+            return [
+                ColumnMissingError(column=column_info),
+            ]
+
+        return []
+
+
+@dataclass(frozen=True)
+class ColumnTypeError(FrameValidationError):
+    column: ColumnInfo
+    actual_type: pl.PolarsDataType
+    expected_type: pl.PolarsDataType
+
+    def get_error_string(self) -> str:
+        return f"{self.column.specification_string}. Expected type '{self.expected_type}', got '{self.actual_type}'."
+
+
+@dataclass(frozen=True)
+class ColumnTypeRule(ValidatorRule):
+    expected_type: pl.PolarsDataType
+
+    def __call__(
+        self,
+        column_info: ColumnInfo,
+        frame: PolarsFrame,
+    ) -> Sequence[ColumnTypeError]:
+        try:
+            column_type = frame.schema[column_info.name]
+        except pl.ColumnNotFoundError:
+            return []
+
+        if column_type == self.expected_type:
+            return []
+
+        return [
+            ColumnTypeError(
+                column=column_info,
+                actual_type=column_type,
+                expected_type=self.expected_type,
+            ),
+        ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ hydra-core==1.3.2
 hydra-joblib-launcher==1.2.0
 hydra-optuna-sweeper==1.2.0
 ipython==7.34.0
-iterpy==22.0
+iterpy==0.22.0
 Levenshtein==0.21.0
 mlflow==2.9.2
 numpy==1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ confection==0.1.3
 deepchecks==0.17.5
 dill==0.3.6
 fakeredis==2.20.0
-functionalpy==0.12.0
 hydra-core==1.3.2
 hydra-joblib-launcher==1.2.0
 hydra-optuna-sweeper==1.2.0
 ipython==7.34.0
+iterpy==22.0
 Levenshtein==0.21.0
 mlflow==2.9.2
 numpy==1.26.0


### PR DESCRIPTION
Fixes #622.

I propose we use this for:
* CohortDefiner's return type
* SplitLoader's return type
* Others?

This ensures that modules which return frames conform to the same return type contract, so they can be swapped interchangeably.

Ignore anything not in the `types` folder, they are just an updated of `functionalpy` to `iterpy`.