### PR TITLE
fix: `RegionalFilter` should not load at init

### DIFF
--- a/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Literal
 
 import polars as pl
@@ -14,39 +15,36 @@ from psycop.common.model_training_v2.trainer.data.data_filters.geographical_spli
 
 
 @BaselineRegistry.data_filters.register("regional_data_filter")
+@dataclass(frozen=True)
 class RegionalFilter(BaselineDataFilter):
-    def __init__(
-        self,
-        regions_to_keep: Sequence[Literal["vest", "midt", "øst"]],
-        id_col_name: str = "dw_ek_borger",
-        timestamp_col_name: str = "timestamp",
-        regional_move_df: pl.LazyFrame | None = None,
-        region_col_name: str = "region",
-        timestamp_cutoff_col_name: str = "first_regional_move_timestamp",
-    ):
-        """Filter data to only include ids from the desired regions. Removes
-        predictions times after the patient has moved to a different region to
-        avoid target leakage. If regional_move_df is None, the standard regional
-        move dataframe is loaded .
+    """Filter data to only include ids from the desired regions. Removes
+    predictions times after the patient has moved to a different region to
+    avoid target leakage. If regional_move_df is None, the standard regional
+    move dataframe is loaded .
 
-        Args:
-            regions_to_keep: The regions to keep
-            id_col_name (str, optional): The name of the id column. Defaults to "dw_ek_borger".
-            timestamp_col_name (str, optional): The name of the timestamp column. Defaults to "timestamp".
-            regional_move_df (pl.LazyFrame | None, optional): The dataframe containing the regional move data. Defaults to None.
-                If supplied, should contain "dw_ek_borger", a region col and a timestamp column indicating when the patient moved.
-            region_col_name (str, optional): The name of the region column in regional_move_df. Defaults to "region".
-            timestamp_cutoff_col_name (str, optional): The name of the timestamp column in regional_move_df to
-                be used for dropping rows after this time. Defaults to "first_regional_move_timestamp".
-        """
-        self.regions_to_keep = regions_to_keep
-        self.id_col_name = id_col_name
-        self.timestamp_col_name = timestamp_col_name
-        self.region_col_name = region_col_name
-        self.timestamp_cutoff_col_name = timestamp_cutoff_col_name
+    Args:
+        regions_to_keep: The regions to keep
+        id_col_name (str, optional): The name of the id column. Defaults to "dw_ek_borger".
+        timestamp_col_name (str, optional): The name of the timestamp column. Defaults to "timestamp".
+        regional_move_df (pl.LazyFrame | None, optional): The dataframe containing the regional move data. Defaults to None.
+            If supplied, should contain "dw_ek_borger", a region col and a timestamp column indicating when the patient moved.
+        region_col_name (str, optional): The name of the region column in regional_move_df. Defaults to "region".
+        timestamp_cutoff_col_name (str, optional): The name of the timestamp column in regional_move_df to
+            be used for dropping rows after this time. Defaults to "first_regional_move_timestamp".
+    """
 
-        if regional_move_df is None:
-            self.filtered_regional_move_df = self._filter_regional_move_df_by_regions(
+    regions_to_keep: Sequence[Literal["vest", "midt", "øst"]]
+    id_col_name: str = "dw_ek_borger"
+    timestamp_col_name: str = "timestamp"
+    regional_move_df: pl.LazyFrame | None = None
+    region_col_name: str = "region"
+    timestamp_cutoff_col_name: str = "first_regional_move_timestamp"
+
+    def apply(self, dataloader: BaselineDataLoader) -> pl.LazyFrame:
+        """Only include data from the first region a patient visits, to avoid
+        target leakage."""
+        if self.regional_move_df is None:
+            filtered_regional_move_df = self._filter_regional_move_df_by_regions(
                 get_regional_split_df().select(
                     "dw_ek_borger",
                     "region",
@@ -54,16 +52,13 @@ class RegionalFilter(BaselineDataFilter):
                 ),
             )
         else:
-            self.filtered_regional_move_df = self._filter_regional_move_df_by_regions(
-                regional_move_df,
+            filtered_regional_move_df = self._filter_regional_move_df_by_regions(
+                self.regional_move_df,
             )
 
-    def apply(self, dataloader: BaselineDataLoader) -> pl.LazyFrame:
-        """Only include data from the first region a patient visits, to avoid
-        target leakage."""
         return (
             dataloader.load()
-            .join(self.filtered_regional_move_df, on=self.id_col_name, how="inner")
+            .join(filtered_regional_move_df, on=self.id_col_name, how="inner")
             .filter(
                 pl.col(self.timestamp_col_name)
                 < pl.col(self.timestamp_cutoff_col_name),

--- a/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
+++ b/psycop/common/model_training_v2/trainer/data/data_filters/geography.py
@@ -43,18 +43,19 @@ class RegionalFilter(BaselineDataFilter):
     def apply(self, dataloader: BaselineDataLoader) -> pl.LazyFrame:
         """Only include data from the first region a patient visits, to avoid
         target leakage."""
-        if self.regional_move_df is None:
-            filtered_regional_move_df = self._filter_regional_move_df_by_regions(
-                get_regional_split_df().select(
-                    "dw_ek_borger",
-                    "region",
-                    "first_regional_move_timestamp",
-                ),
+        regional_move_df = (
+            get_regional_split_df().select(
+                "dw_ek_borger",
+                "region",
+                "first_regional_move_timestamp",
             )
-        else:
-            filtered_regional_move_df = self._filter_regional_move_df_by_regions(
-                self.regional_move_df,
-            )
+            if self.regional_move_df is None
+            else self.regional_move_df
+        )
+
+        filtered_regional_move_df = self._filter_regional_move_df_by_regions(
+            regional_move_df,
+        )
 
         return (
             dataloader.load()


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
Helps in that:
1. Registry resolution is faster, since it does not need to wait on loading
2. Registry resolution can happen in tests, since it does not need access to the SQL database. Required for #638.