### PR TITLE
fix: literal type hint parsing

### DIFF
--- a/psycop/common/model_training_v2/config/test_unpack_annotations.py
+++ b/psycop/common/model_training_v2/config/test_unpack_annotations.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any, Literal
 
 import pytest
 
@@ -22,6 +23,7 @@ class UnpackExpectation:
     [
         UnpackExpectation(str, "str"),
         UnpackExpectation(Sequence[MyType], "Sequence[MyType]"),
+        UnpackExpectation(Literal[1, 2, 3], "Literal[1, 2, 3]"),  # type: ignore
         UnpackExpectation(MyType, "MyType"),
         UnpackExpectation(int | str, "int | str"),
         UnpackExpectation(str | None, "str | None"),

--- a/psycop/common/model_training_v2/config/test_unpack_annotations.py
+++ b/psycop/common/model_training_v2/config/test_unpack_annotations.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Literal
 
 import pytest
 

--- a/psycop/common/model_training_v2/config/unpack_annotations.py
+++ b/psycop/common/model_training_v2/config/unpack_annotations.py
@@ -27,8 +27,7 @@ def get_pretty_type_str(annotation: types.GenericAlias | type) -> str:
     """Recursively unpacks an annotation to a string representation."""
     try:
         contained_type_strings = [
-            get_pretty_type_str(arg)
-            for arg in annotation.__args__  # type: ignore
+            get_pretty_type_str(arg) for arg in annotation.__args__  # type: ignore
         ]
         wrapping_type = get_wrapping_type(annotation)  # type: ignore
         return wrapping_type.to_wrapped_annotation(contained_type_strings)

--- a/psycop/common/model_training_v2/config/unpack_annotations.py
+++ b/psycop/common/model_training_v2/config/unpack_annotations.py
@@ -1,4 +1,5 @@
 import types
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 
@@ -7,30 +8,34 @@ class TypeWrapper:
     name: str
     prefix: str
     suffix: str
+    separator: str
 
-    def to_wrapped_annotation(self, annotation: str) -> str:
-        return f"{self.name}{self.prefix}{annotation}{self.suffix}"
+    def to_wrapped_annotation(self, wrapped_types: Sequence[str]) -> str:
+        return (
+            f"{self.name}{self.prefix}{self.separator.join(wrapped_types)}{self.suffix}"
+        )
 
 
 def get_wrapping_type(annotation: types.GenericAlias) -> TypeWrapper:
     """Get the name of an annotation, including how it wraps contained annotations."""
     if isinstance(annotation, types.UnionType):
-        return TypeWrapper(name="", prefix="", suffix="")
-    return TypeWrapper(name=annotation.__name__, prefix="[", suffix="]")
+        return TypeWrapper(name="", prefix="", suffix="", separator=" | ")
+    return TypeWrapper(name=annotation.__name__, prefix="[", suffix="]", separator=", ")
 
 
 def get_pretty_type_str(annotation: types.GenericAlias | type) -> str:
     """Recursively unpacks an annotation to a string representation."""
     try:
         contained_type_strings = [
-            get_pretty_type_str(arg) for arg in annotation.__args__  # type: ignore
+            get_pretty_type_str(arg)
+            for arg in annotation.__args__  # type: ignore
         ]
         wrapping_type = get_wrapping_type(annotation)  # type: ignore
-        return wrapping_type.to_wrapped_annotation(
-            " | ".join(contained_type_strings),
-        )
+        return wrapping_type.to_wrapped_annotation(contained_type_strings)
     # If it contains no args, it is not a wrapping type. Just return the type.
     except AttributeError:
         if annotation is types.NoneType:
             return "None"
+        if any(isinstance(annotation, value) for value in [int, float]):
+            return str(annotation)
         return annotation.__name__


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
