### PR TITLE
refactor: hide geographical split loading inside the `RegionalSplit` class

### DIFF
--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
-from psycop.common.model_training_v2.trainer.preprocessing.steps.geographical_split.make_geographical_split import (
-    get_regional_split_df,
+from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
+    _get_regional_split_df,  # type: ignore
 )
 
 from ....types.validated_frame import ValidatedFrame
@@ -76,7 +76,7 @@ def load_stratified_by_region_split_ids(
         pd.DataFrame: Only dw_ek_borger column with ids
     """
     split_df = (
-        get_regional_split_df()
+        _get_regional_split_df()
         .filter(pl.col("split") == split.value)
         .select("dw_ek_borger")
         .collect()

--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -9,9 +9,6 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from psycop.common.feature_generation.loaders.raw.sql_load import sql_load
-from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
-    _get_regional_split_df,  # type: ignore
-)
 
 from ....types.validated_frame import ValidatedFrame
 from ....types.validator_rules import ColumnExistsRule, ColumnTypeRule, ValidatorRule
@@ -57,35 +54,6 @@ def load_stratified_by_outcome_split_ids(
 
     return SplitFrame(
         frame=pl.from_pandas(df.reset_index(drop=True)).lazy(),
-        split_name=split.value,
-        allow_extra_columns=True,
-    )
-
-
-def load_stratified_by_region_split_ids(
-    split: SplitName,
-    n_rows: int | None = None,
-) -> SplitFrame:
-    """Loads ids for a given split using the region-based split.
-
-    Args:
-        split: Which split to load IDs from. Takes either "train", "test" or "val".
-        n_rows: Number of rows to return. Defaults to None.
-
-    Returns:
-        pd.DataFrame: Only dw_ek_borger column with ids
-    """
-    split_df = (
-        _get_regional_split_df()
-        .filter(pl.col("split") == split.value)
-        .select("dw_ek_borger")
-        .collect()
-    )
-    if n_rows is not None:
-        split_df = split_df.head(n_rows)
-
-    return SplitFrame(
-        frame=split_df.lazy(),
         split_name=split.value,
         allow_extra_columns=True,
     )

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/geographical_split/_geographical_split.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/geographical_split/_geographical_split.py
@@ -3,10 +3,6 @@ from pathlib import Path
 
 import polars as pl
 
-from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
-    _get_regional_split_df,  # type: ignore
-)
-
 
 def load_shak_to_location_mapping() -> pl.DataFrame:
     """vest = herning, holstebro, gødstrup
@@ -91,7 +87,3 @@ def add_shak_to_region_mapping(
         .filter(~pl.col("shak_6").is_in(shak_codes_to_drop))
         .select("dw_ek_borger", "timestamp", "region")
     )
-
-
-if __name__ == "__main__":
-    _get_regional_split_df()

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/geographical_split/_geographical_split.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/geographical_split/_geographical_split.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import polars as pl
 
-from psycop.common.feature_generation.loaders.raw.load_visits import physical_visits
+from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
+    _get_regional_split_df,  # type: ignore
+)
 
 
 def load_shak_to_location_mapping() -> pl.DataFrame:
@@ -91,57 +93,5 @@ def add_shak_to_region_mapping(
     )
 
 
-def get_regional_split_df() -> pl.LazyFrame:
-    """Return a dataframe with the region at which each patient first had
-    a contact. If a patient had contacts at multiple regions, the timestamp
-    of the first contact at a different region is also included."""
-    shak_to_location_df = load_shak_to_location_mapping()
-
-    visits = pl.from_pandas(physical_visits(shak_code=6600, return_shak_location=True))
-
-    sorted_all_visits_df = add_shak_to_region_mapping(
-        visits=visits,
-        shak_to_location_df=shak_to_location_df,
-        shak_codes_to_drop=non_adult_psychiatry_shak(),
-    ).sort(["dw_ek_borger", "timestamp"])
-
-    # find timestamp of first visit at each different region
-    first_visit_at_each_region = get_first_visit_at_each_region_by_patient(
-        df=sorted_all_visits_df,
-    )
-
-    # get the first visit
-    first_visit_at_first_region = get_first_visit_by_patient(
-        df=first_visit_at_each_region,
-    )
-
-    # get the first visit at a different region
-    first_visit_at_second_region = get_first_visit_at_second_region_by_patient(
-        df=first_visit_at_each_region,
-    )
-
-    # add the migration date for each patient
-    geographical_split_df = add_migration_date_by_patient(
-        first_visit_at_first_region,
-        first_visit_at_second_region,
-    )
-    # add indicator for which split each patient belongs to
-    geographical_split_df = geographical_split_df.with_columns(
-        pl.when(pl.col("region") == "øst")
-        .then("train")
-        .when(pl.col("region") == "vest")
-        .then("val")
-        .otherwise("test")
-        .alias("split"),
-    )
-
-    return geographical_split_df.select(
-        "dw_ek_borger",
-        "region",
-        "first_regional_move_timestamp",
-        "split",
-    ).lazy()
-
-
 if __name__ == "__main__":
-    get_regional_split_df()
+    _get_regional_split_df()

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/geographical_split/test_geographical_split.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/geographical_split/test_geographical_split.py
@@ -2,7 +2,7 @@ import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
 
-from psycop.common.model_training_v2.trainer.preprocessing.steps.geographical_split.make_geographical_split import (
+from psycop.common.model_training_v2.trainer.preprocessing.steps.geographical_split._geographical_split import (
     add_migration_date_by_patient,
     add_shak_to_region_mapping,
     get_first_visit_at_each_region_by_patient,

--- a/psycop/projects/scz_bp/data_inspection/scz_bp_age_at_outcome.py
+++ b/psycop/projects/scz_bp/data_inspection/scz_bp_age_at_outcome.py
@@ -6,8 +6,8 @@ import plotnine as pn
 import polars as pl
 
 from psycop.common.feature_generation.loaders.raw.load_demographic import birthdays
-from psycop.common.model_training_v2.trainer.preprocessing.steps.geographical_split.make_geographical_split import (
-    get_regional_split_df,
+from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
+    _get_regional_split_df,  # type: ignore
 )
 from psycop.projects.scz_bp.feature_generation.eligible_prediction_times.scz_bp_eligible_config import (
     N_DAYS_WASHIN,
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     birthday_df = pl.from_pandas(birthdays())
 
     train_val_ids = (
-        get_regional_split_df()
+        _get_regional_split_df()
         .filter(pl.col("region").is_in(["øst", "vest"]))
         .collect()
     )

--- a/psycop/projects/scz_bp/data_inspection/scz_bp_time_of_first_contact_to_outcome.py
+++ b/psycop/projects/scz_bp/data_inspection/scz_bp_time_of_first_contact_to_outcome.py
@@ -2,8 +2,8 @@
 import plotnine as pn
 import polars as pl
 
-from psycop.common.model_training_v2.trainer.preprocessing.steps.geographical_split.make_geographical_split import (
-    get_regional_split_df,
+from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
+    _get_regional_split_df,  # type: ignore
 )
 from psycop.projects.scz_bp.feature_generation.outcome_specification.first_scz_or_bp_diagnosis import (
     get_first_scz_or_bp_diagnosis_with_time_from_first_contact,
@@ -24,7 +24,7 @@ def print_summary_stats(df: pl.DataFrame) -> None:
 if __name__ == "__main__":
     df = get_first_scz_or_bp_diagnosis_with_time_from_first_contact()
     train_val_ids = (
-        get_regional_split_df()
+        _get_regional_split_df()
         .filter(pl.col("region").is_in(["øst", "vest"]))
         .collect()
     )

--- a/psycop/projects/scz_bp/dataset_description/scz_bp_table_one.py
+++ b/psycop/projects/scz_bp/dataset_description/scz_bp_table_one.py
@@ -44,8 +44,8 @@ from psycop.common.model_training_v2.config.populate_registry import (
 from psycop.common.model_training_v2.trainer.data.dataloaders import (
     ParquetVerticalConcatenator,
 )
-from psycop.common.model_training_v2.trainer.preprocessing.steps.geographical_split.make_geographical_split import (
-    get_regional_split_df,
+from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_split import (
+    _get_regional_split_df,  # type: ignore
 )
 from psycop.projects.scz_bp.feature_generation.outcome_specification.add_time_from_first_visit import (
     time_of_first_contact_to_psychiatry,
@@ -338,7 +338,7 @@ class SczBpTableOne:
     @staticmethod
     def add_split(df: pl.DataFrame) -> pl.DataFrame:
         split_df = (
-            get_regional_split_df()
+            _get_regional_split_df()
             .collect()
             .with_columns(
                 pl.when(pl.col("region").is_in(["øst", "vest"]))


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->

Fixes #658.

@HLasse I've type-ignored the places where you use the private function. This could probably be fixed by using the `RegionalFilter`, and would be a good example to set when others look at your code as well. That said, up to you 👍 