### PR TITLE
dev: make default build task idempotent

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,7 +29,6 @@
             "type": "shell",
             "command": "inv lint --auto-fix",
             "presentation": {
-                "reveal": "always",
                 "group": "pr",
                 "clear": true,
                 "showReuseMessage": false,
@@ -40,7 +39,6 @@
             "type": "shell",
             "command": "inv qtest",
             "presentation": {
-                "reveal": "always",
                 "group": "pr",
                 "clear": true,
                 "showReuseMessage": false,
@@ -52,7 +50,6 @@
             "command": "echo '🚧️ Any problems in the PR? Press Ctrl+C to cancel.' && herb submit",
             "presentation": {
                 "group": "pr",
-                "reveal": "always",
                 "revealProblems": "onProblem",
                 "focus": true,
                 "clear": true,
@@ -64,7 +61,6 @@
             "type": "shell",
             "command": "inv qtypes",
             "presentation": {
-                "reveal": "always",
                 "group": "pr",
                 "clear": true,
                 "showReuseMessage": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,7 +49,7 @@
         {
             "label": "Submit PR",
             "type": "shell",
-            "command": "herb submit && echo '⚠️ Any problems in the PR? Press Ctrl+C to cancel.'",
+            "command": "echo '🚧️ Any problems in the PR? Press Ctrl+C to cancel.' && herb submit",
             "presentation": {
                 "group": "pr",
                 "reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
             "dependsOn": [
                 "Lint",
                 "Test",
-                "Actions requiring input"
+                "Submit PR"
             ],
             "presentation": {
                 "reveal": "never",
@@ -47,9 +47,9 @@
             }
         },
         {
-            "label": "Actions requiring input",
+            "label": "Submit PR",
             "type": "shell",
-            "command": "inv qtypes && inv prompt-to-submit-pr --skip-submit-prompt",
+            "command": "herb submit",
             "presentation": {
                 "group": "pr",
                 "reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,7 +49,7 @@
         {
             "label": "Submit PR",
             "type": "shell",
-            "command": "herb submit",
+            "command": "herb submit && echo '⚠️ Any problems in the PR? Press Ctrl+C to cancel.'",
             "presentation": {
                 "group": "pr",
                 "reveal": "always",


### PR DESCRIPTION
I've disabled type checks when running through `tasks.json` – it is _much_ faster to look whether there are any problems in the problems tab.

I don't have a strong opinion on this, so open to suggestions @HLasse 👍 