### PR TITLE
fix: correct types for id col in splitframe

### DIFF
--- a/psycop/common/feature_generation/loaders/raw/load_ids.py
+++ b/psycop/common/feature_generation/loaders/raw/load_ids.py
@@ -29,7 +29,7 @@ class SplitFrame(ValidatedFrame[pl.LazyFrame]):
     id_col_name: str = "dw_ek_borger"
     id_col_rules: Sequence[ValidatorRule] = (
         ColumnExistsRule(),
-        ColumnTypeRule(expected_type=pl.Utf8),
+        ColumnTypeRule(expected_type=pl.Int64),
     )
 
 


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
