### PR TITLE
feat(#709): support temporary uuid in quarantine filter

### DIFF
--- a/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/quarantine_filter/quarantine_filter_20240115_120142.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/quarantine_filter/quarantine_filter_20240115_120142.cfg
@@ -1,7 +1,6 @@
 [placeholder]
 @preprocessing = "quarantine_filter"
 entity_id_col_name = "str"
-pred_time_uuid_col_name = "str"
 timestamp_col_name = "str"
 quarantine_timestamps_loader = {"@data":"minimal_test_data"}
 quarantine_interval_days = 2

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/row_filter_other.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/row_filter_other.py
@@ -54,11 +54,11 @@ class WindowFilter(PresplitStep):
 @dataclass(frozen=True)
 class QuarantineFilter:
     entity_id_col_name: str
-    pred_time_uuid_col_name: str
     timestamp_col_name: str
     quarantine_timestamps_loader: BaselineDataLoader
     quarantine_interval_days: int
     validate_on_init: bool = True
+    _tmp_pred_time_uuid_col_name = "_tmp_pred_time_uuid"
 
     def __post_init__(self) -> None:
         required_columns = [self.timestamp_col_name, self.entity_id_col_name]
@@ -71,12 +71,38 @@ class QuarantineFilter:
                 f"'{self.entity_id_col_name}'",
             )
 
+    def _generate_pred_time_uuid_column(self, input_df: pl.LazyFrame) -> pl.LazyFrame:
+        input_df = input_df.with_columns(
+            pl.concat_str(
+                [
+                    pl.col(self.entity_id_col_name).cast(pl.Utf8),
+                    pl.lit("-"),
+                    pl.col(self.timestamp_col_name).dt.strftime(
+                        "%Y-%m-%d-%H-%M-%S",
+                    ),
+                ],
+            ).alias(self._tmp_pred_time_uuid_col_name),
+        )
+
+        return input_df
+
     def apply(self, input_df: pl.LazyFrame) -> pl.LazyFrame:
         # We need to check if ANY quarantine date hits each prediction time.
         # Create combinations
 
+        added_pred_time_uuid_col = False
+        quarantine_timestamps_df = self.quarantine_timestamps_loader.load()
+
+        if self._tmp_pred_time_uuid_col_name not in input_df.columns:
+            input_df = self._generate_pred_time_uuid_column(input_df)
+            added_pred_time_uuid_col = True
+        if self._tmp_pred_time_uuid_col_name not in quarantine_timestamps_df.columns:
+            quarantine_timestamps_df = self._generate_pred_time_uuid_column(
+                quarantine_timestamps_df,
+            )
+
         df_with_quarantine_timestamps = input_df.join(
-            self.quarantine_timestamps_loader.load().rename(
+            quarantine_timestamps_df.rename(
                 {self.timestamp_col_name: "timestamp_quarantine"},
             ),
             on=self.entity_id_col_name,
@@ -93,12 +119,16 @@ class QuarantineFilter:
         hit_by_quarantine = time_since_quarantine.filter(
             (pl.col("days_since_quarantine") < self.quarantine_interval_days)
             & (pl.col("days_since_quarantine") > 0),
-        ).select(self.pred_time_uuid_col_name)
+        ).select(self._tmp_pred_time_uuid_col_name)
 
         # Use these rows to filter the prediction times, ensuring that all columns are kept
         df = input_df.join(
             hit_by_quarantine,
-            on=self.pred_time_uuid_col_name,
+            on=self._tmp_pred_time_uuid_col_name,
             how="anti",
         )
+
+        if added_pred_time_uuid_col:
+            df = df.drop(self._tmp_pred_time_uuid_col_name)
+
         return df

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/test_row_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/test_row_filters.py
@@ -107,7 +107,6 @@ def test_filter_by_quarantine_period():
         1,2026-02-01 00:00:01, # keep: outside quarantine days from the first quarantine date
         2,2023-02-01 00:00:01, # keep: no quarantine date for this id
         """,
-        add_pred_time_uuid=True,
     ).lazy()
 
     expected_df = str_to_pl_df(
@@ -116,7 +115,6 @@ def test_filter_by_quarantine_period():
         1,2026-02-01 00:00:01,
         2,2023-02-01 00:00:01,
         """,
-        add_pred_time_uuid=True,
     )
 
     result_df = (
@@ -125,7 +123,6 @@ def test_filter_by_quarantine_period():
             quarantine_interval_days=quarantine_days,
             quarantine_timestamps_loader=TestDataLoader(),
             timestamp_col_name="timestamp",
-            pred_time_uuid_col_name="pred_time_uuid",
         )
         .apply(prediction_time_df)
         .collect()


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->

When using the quarantine filter in cohort definers, the pred times have not had uuids generated yet. We probably don't want that as a requirement, so instead, we can generate a tmp uuid for this filter. Let me know what you think 👍 