### PR TITLE
refactor: rename registry to SequenceRegistry

### DIFF
--- a/psycop/common/feature_generation/sequences/event_loader.py
+++ b/psycop/common/feature_generation/sequences/event_loader.py
@@ -3,7 +3,7 @@ from typing import Protocol, runtime_checkable
 
 import polars as pl
 
-from ...sequence_models.registry import Registry
+from ...sequence_models.registry import SequenceRegistry
 from ..loaders.raw.sql_load import sql_load
 
 
@@ -14,7 +14,7 @@ class EventLoader(Protocol):
         ...
 
 
-@Registry.event_loaders.register("diagnoses")
+@SequenceRegistry.event_loaders.register("diagnoses")
 class DiagnosisLoader(EventLoader):
     """Load all diagnoses for all patients."""
 

--- a/psycop/common/feature_generation/sequences/patient_loader.py
+++ b/psycop/common/feature_generation/sequences/patient_loader.py
@@ -15,7 +15,7 @@ from psycop.common.feature_generation.sequences.patient_slice_from_events import
 )
 
 from ...model_training_v2.trainer.preprocessing.step import PresplitStep
-from ...sequence_models.registry import Registry
+from ...sequence_models.registry import SequenceRegistry
 
 
 def keep_if_min_n_visits(
@@ -29,7 +29,7 @@ def keep_if_min_n_visits(
     return df
 
 
-@Registry.datasets.register("patient_loader")
+@SequenceRegistry.datasets.register("patient_loader")
 @dataclass(frozen=True)
 class PatientLoader:
     event_loaders: Sequence[EventLoader]

--- a/psycop/common/feature_generation/sequences/patient_slice_collater.py
+++ b/psycop/common/feature_generation/sequences/patient_slice_collater.py
@@ -7,7 +7,7 @@ from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_spli
     RegionalFilter,
 )
 from psycop.common.sequence_models.dataset import PatientSliceDataset
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 
 
 @runtime_checkable
@@ -16,7 +16,7 @@ class BasePatientSliceCollater(Protocol):
         ...
 
 
-@Registry.datasets.register("unlabelled_slice_creator")
+@SequenceRegistry.datasets.register("unlabelled_slice_creator")
 @dataclass(frozen=True)
 class PatientSliceCollater(BasePatientSliceCollater):
     patient_loader: PatientLoader

--- a/psycop/common/feature_generation/sequences/prediction_time_collater.py
+++ b/psycop/common/feature_generation/sequences/prediction_time_collater.py
@@ -12,7 +12,7 @@ from psycop.common.model_training_v2.trainer.preprocessing.steps.row_filter_spli
     RegionalFilter,
 )
 from psycop.common.sequence_models.dataset import PredictionTimeDataset
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 from psycop.projects.t2d.feature_generation.cohort_definition.t2d_cohort_definer import (
     T2DCohortDefiner,
 )
@@ -24,7 +24,7 @@ class BasePredictionTimeCollater(Protocol):
         ...
 
 
-@Registry.datasets.register("prediction_time_collater")
+@SequenceRegistry.datasets.register("prediction_time_collater")
 @dataclass(frozen=True)
 class PredictionTimeCollater(BasePredictionTimeCollater):
     patient_loader: PatientLoader

--- a/psycop/common/sequence_models/aggregators.py
+++ b/psycop/common/sequence_models/aggregators.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 import torch
 from torch import nn
 
-from .registry import Registry
+from .registry import SequenceRegistry
 
 
 class Aggregator(nn.Module):
@@ -16,7 +16,7 @@ class Aggregator(nn.Module):
         pass
 
 
-@Registry.layers.register("cls_aggregator")
+@SequenceRegistry.layers.register("cls_aggregator")
 class CLSAggregator(Aggregator):
     """
     Takes the hidden state corresponding to the first token (i.e. the CLS token).
@@ -33,7 +33,7 @@ class CLSAggregator(Aggregator):
         return last_hidden[:, 0, :]
 
 
-@Registry.layers.register("average_pooler")
+@SequenceRegistry.layers.register("average_pooler")
 class AveragePooler(Aggregator):
     """
     Parameter-free poolers to get the sentence embedding

--- a/psycop/common/sequence_models/callbacks.py
+++ b/psycop/common/sequence_models/callbacks.py
@@ -7,15 +7,15 @@ from typing import Literal
 
 from lightning.pytorch.callbacks import Callback, LearningRateMonitor, ModelCheckpoint
 
-from .registry import Registry
+from .registry import SequenceRegistry
 
 
-@Registry.callbacks.register("callback_list")
+@SequenceRegistry.callbacks.register("callback_list")
 def create_callback_list(*args: Callback) -> list[Callback]:
     return list(args)
 
 
-@Registry.callbacks.register("model_checkpoint")
+@SequenceRegistry.callbacks.register("model_checkpoint")
 def create_model_checkpoint(
     save_dir: Path,
     every_n_epochs: int = 1,
@@ -33,7 +33,7 @@ def create_model_checkpoint(
     )
 
 
-@Registry.callbacks.register("learning_rate_monitor")
+@SequenceRegistry.callbacks.register("learning_rate_monitor")
 def create_learning_rate_monitor(
     logging_interval: str = "epoch",
 ) -> LearningRateMonitor:

--- a/psycop/common/sequence_models/config_utils.py
+++ b/psycop/common/sequence_models/config_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from confection import Config
 
 from psycop.common.sequence_models.config_schema import ResolvedConfigSchema
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 
 default_config_path = Path(__file__).parent / "default_config.cfg"
 
@@ -21,5 +21,5 @@ def load_config(config_path: Path | None = None) -> Config:
 
 
 def parse_config(config: Config) -> ResolvedConfigSchema:
-    cfg = Registry.resolve(config)
+    cfg = SequenceRegistry.resolve(config)
     return ResolvedConfigSchema(**cfg)

--- a/psycop/common/sequence_models/embedders/BEHRT_embedders.py
+++ b/psycop/common/sequence_models/embedders/BEHRT_embedders.py
@@ -19,7 +19,7 @@ from psycop.common.data_structures.patient import PatientSlice
 from ...feature_generation.sequences.patient_slice_collater import (
     BasePatientSliceCollater,
 )
-from ..registry import Registry
+from ..registry import SequenceRegistry
 from .interface import EmbeddedSequence, PatientSliceEmbedder
 
 log = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class BEHRTVocab:
     position: dict[str, int] = field(default_factory=lambda: {"PAD": 0})
 
 
-@Registry.embedders.register("behrt_embedder")
+@SequenceRegistry.embedders.register("behrt_embedder")
 class BEHRTEmbedder(nn.Module, PatientSliceEmbedder):
     def __init__(
         self,

--- a/psycop/common/sequence_models/logger.py
+++ b/psycop/common/sequence_models/logger.py
@@ -6,7 +6,7 @@ from lightning.pytorch.loggers import Logger as plLogger
 from lightning.pytorch.loggers.mlflow import MLFlowLogger as plMLFlowLogger
 from lightning.pytorch.loggers.wandb import WandbLogger as plWandbLogger
 
-from .registry import Registry
+from .registry import SequenceRegistry
 
 
 def handle_wandb_folder():
@@ -20,7 +20,7 @@ def handle_wandb_folder():
         )
 
 
-@Registry.loggers.register("wandb")
+@SequenceRegistry.loggers.register("wandb")
 def create_wandb_logger(
     save_dir: Path | str,
     experiment_name: str,
@@ -37,7 +37,7 @@ def create_wandb_logger(
     )
 
 
-@Registry.loggers.register("mlflow")
+@SequenceRegistry.loggers.register("mlflow")
 def create_mlflow_logger(
     save_dir: Path | str,
     experiment_name: str,

--- a/psycop/common/sequence_models/model_layers.py
+++ b/psycop/common/sequence_models/model_layers.py
@@ -1,9 +1,9 @@
 from torch import nn
 
-from .registry import Registry
+from .registry import SequenceRegistry
 
 
-@Registry.layers.register("transformer_encoder_layer")
+@SequenceRegistry.layers.register("transformer_encoder_layer")
 def create_encoder_layer(
     d_model: int,
     nhead: int,
@@ -21,6 +21,6 @@ def create_encoder_layer(
     )
 
 
-@Registry.layers.register("transformer_encoder")
+@SequenceRegistry.layers.register("transformer_encoder")
 def create_transformers_encoder(num_layers: int, encoder_layer: nn.Module) -> nn.Module:
     return nn.TransformerEncoder(encoder_layer, num_layers=num_layers)

--- a/psycop/common/sequence_models/optimizers.py
+++ b/psycop/common/sequence_models/optimizers.py
@@ -6,7 +6,7 @@ import torch
 from torch.optim.lr_scheduler import _LRScheduler  # , # type: ignore
 from transformers import get_linear_schedule_with_warmup
 
-from .registry import Registry
+from .registry import SequenceRegistry
 
 OptimizerFn = Callable[[Iterable[torch.nn.parameter.Parameter]], torch.optim.Optimizer]
 LRSchedulerFn = Callable[[torch.optim.Optimizer], _LRScheduler]
@@ -26,12 +26,12 @@ def _configure_adamw(
     return torch.optim.AdamW(parameters, lr=lr)
 
 
-@Registry.optimizers.register("adam")
+@SequenceRegistry.optimizers.register("adam")
 def create_adam(lr: float) -> OptimizerFn:
     return partial(_configure_adam, lr=lr)
 
 
-@Registry.optimizers.register("adamw")
+@SequenceRegistry.optimizers.register("adamw")
 def create_adamw(lr: float) -> OptimizerFn:
     return partial(_configure_adamw, lr=lr)
 
@@ -50,7 +50,7 @@ def _configure_linear_schedule_with_warmup(
     )
 
 
-@Registry.lr_schedulers.register("linear_schedule_with_warmup")
+@SequenceRegistry.lr_schedulers.register("linear_schedule_with_warmup")
 def create_linear_schedule_with_warmup(
     num_warmup_steps: int,
     num_training_steps: int,

--- a/psycop/common/sequence_models/registry.py
+++ b/psycop/common/sequence_models/registry.py
@@ -4,7 +4,7 @@ import catalogue
 from confection import registry
 
 
-class Registry(registry):
+class SequenceRegistry(registry):
     tasks = catalogue.create("psycop", "encoders")
     layers = catalogue.create("psycop", "layers")
     embedders = catalogue.create("psycop", "embedders")
@@ -24,6 +24,6 @@ class Registry(registry):
 T = TypeVar("T")
 
 
-@Registry.utilities.register("list_creator")
+@SequenceRegistry.utilities.register("list_creator")
 def list_creator(*args: T) -> list[T]:
     return list(args)

--- a/psycop/common/sequence_models/tasks/patientslice_classifier.py
+++ b/psycop/common/sequence_models/tasks/patientslice_classifier.py
@@ -17,14 +17,14 @@ from ..aggregators import Aggregator
 from ..datatypes import BatchWithLabels
 from ..embedders.interface import PatientSliceEmbedder
 from ..optimizers import LRSchedulerFn, OptimizerFn
-from ..registry import Registry
+from ..registry import SequenceRegistry
 from .patientslice_classifier_base import (
     BasePredictionTimeClassifier,
     PredictedProbabilities,
 )
 
 
-@Registry.tasks.register("patient_slice_classifier")
+@SequenceRegistry.tasks.register("patient_slice_classifier")
 @final  # This is not an ABC, must not contain abstract methods
 class PatientSliceClassifier(BasePredictionTimeClassifier):
     def __init__(

--- a/psycop/common/sequence_models/tasks/pretrainer_behrt.py
+++ b/psycop/common/sequence_models/tasks/pretrainer_behrt.py
@@ -11,14 +11,14 @@ from psycop.common.sequence_models.datatypes import BatchWithLabels
 
 from ..embedders.BEHRT_embedders import BEHRTEmbedder
 from ..optimizers import LRSchedulerFn, OptimizerFn
-from ..registry import Registry
+from ..registry import SequenceRegistry
 from .pretrainer_base import BasePatientSlicePretrainer, Metrics
 
 log = logging.getLogger(__name__)
 
 
 # TODO: Align filename
-@Registry.tasks.register("behrt")
+@SequenceRegistry.tasks.register("behrt")
 @final  # This is not an ABC, must not contain abstract methods
 class PretrainerBEHRT(BasePatientSlicePretrainer):
     """An implementation of the BEHRT model for the masked language modeling task."""

--- a/psycop/common/sequence_models/tests/test_finetuning.py
+++ b/psycop/common/sequence_models/tests/test_finetuning.py
@@ -10,13 +10,13 @@ from psycop.common.feature_generation.sequences.prediction_time_collater import 
     BasePredictionTimeCollater,
 )
 from psycop.common.sequence_models.dataset import PredictionTimeDataset
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 from psycop.common.sequence_models.train import train
 
 from .test_encoder_for_clf import arm_within_docker
 
 
-@Registry.datasets.register("fake_patient_slices_with_labels")
+@SequenceRegistry.datasets.register("fake_patient_slices_with_labels")
 class FakePredictionTimeCollater(BasePredictionTimeCollater):
     def __init__(self):
         pass

--- a/psycop/common/sequence_models/tests/test_train.py
+++ b/psycop/common/sequence_models/tests/test_train.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from psycop.common.sequence_models.dataset import PatientSliceDataset
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 from psycop.common.sequence_models.train import train
 
 from ...feature_generation.sequences.patient_slice_collater import (
@@ -12,7 +12,7 @@ from ...feature_generation.sequences.patient_slice_collater import (
 from .utils import create_patients
 
 
-@Registry.datasets.register("test_dataset")
+@SequenceRegistry.datasets.register("test_dataset")
 class FakeSliceCreator(BasePatientSliceCollater):
     def __init__(self):
         pass

--- a/psycop/projects/sequence_models/finetune_t2d.py
+++ b/psycop/projects/sequence_models/finetune_t2d.py
@@ -4,19 +4,19 @@ from pathlib import Path
 from torch import nn
 
 from psycop.common.sequence_models.embedders.BEHRT_embedders import BEHRTEmbedder
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 from psycop.common.sequence_models.tasks import PretrainerBEHRT
 from psycop.common.sequence_models.train import train
 
 
-@Registry.tasks.register("model_from_checkpoint")
+@SequenceRegistry.tasks.register("model_from_checkpoint")
 def load_model_from_checkpoint(
     checkpoint_path: Path,
 ) -> PretrainerBEHRT:
     return PretrainerBEHRT.load_from_checkpoint(checkpoint_path)
 
 
-@Registry.tasks.register("embedder_from_checkpoint")
+@SequenceRegistry.tasks.register("embedder_from_checkpoint")
 def load_embedder_from_checkpoint(
     checkpoint_path: Path,
 ) -> BEHRTEmbedder:
@@ -24,7 +24,7 @@ def load_embedder_from_checkpoint(
     return model.embedder
 
 
-@Registry.tasks.register("encoder_from_checkpoint")
+@SequenceRegistry.tasks.register("encoder_from_checkpoint")
 def load_encoder_from_checkpoint(
     checkpoint_path: Path,
 ) -> nn.Module:

--- a/psycop/projects/t2d/feature_generation/cohort_definition/t2d_cohort_definer.py
+++ b/psycop/projects/t2d/feature_generation/cohort_definition/t2d_cohort_definer.py
@@ -10,7 +10,7 @@ from psycop.common.feature_generation.loaders.raw.load_demographic import birthd
 from psycop.common.feature_generation.loaders.raw.load_visits import (
     physical_visits_to_psychiatry,
 )
-from psycop.common.sequence_models.registry import Registry
+from psycop.common.sequence_models.registry import SequenceRegistry
 from psycop.projects.t2d.feature_generation.cohort_definition.eligible_prediction_times.single_filters import (
     NoIncidentDiabetes,
     T2DMinAgeFilter,
@@ -25,7 +25,7 @@ from psycop.projects.t2d.feature_generation.cohort_definition.outcome_specificat
 msg = Printer(timestamp=True)
 
 
-@Registry.cohorts.register("t2d")
+@SequenceRegistry.cohorts.register("t2d")
 class T2DCohortDefiner(CohortDefiner):
     @staticmethod
     def get_filtered_prediction_times_bundle() -> FilteredPredictionTimeBundle:


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->

Makes it easier to separate from the baseline registry. Was indicated for registering the new regionalsplitfilter within a scope accessible by the sequence models (used in #716). 
Hope it's OK with you @KennethEnevoldsen?

I wonder why that's necessary, though. Not sure I quite understand the namespacing of registries. Would love a chat about it if you have time @KennethEnevoldsen.