### PR TITLE
dev: autofix on commit with lefthook

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
-	"postStartCommand": "pip install -r dev-requirements.txt -r requirements.txt -r gpu-requirements.txt -r test-requirements.txt && gt user pager --disable"
+	"postStartCommand": "bash ./.devcontainer/post-start.sh"
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,10 @@
+# Setup lefthook
+git init
+lefthook install
+
+# Disable Graphite pager
+gt user pager --disable
+
+# Install dependencies
+inv install-requirements
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,9 +12,9 @@
                 "isDefault": true
             },
             "dependsOn": [
-                "Lint",
                 "Test",
-                "Submit PR"
+                "Submit PR",
+                "Types",
             ],
             "presentation": {
                 "reveal": "never",
@@ -25,19 +25,9 @@
             "problemMatcher": []
         },
         {
-            "label": "Lint",
-            "type": "shell",
-            "command": "inv lint --auto-fix",
-            "presentation": {
-                "group": "pr",
-                "clear": true,
-                "showReuseMessage": false,
-            }
-        },
-        {
             "label": "Test",
             "type": "shell",
-            "command": "inv qtest",
+            "command": "lefthook run test",
             "presentation": {
                 "group": "pr",
                 "clear": true,
@@ -47,7 +37,7 @@
         {
             "label": "Submit PR",
             "type": "shell",
-            "command": "echo '🚧️ Any problems in the PR? Press Ctrl+C to cancel.' && lumberman sync --squash",
+            "command": "lumberman sync --squash",
             "presentation": {
                 "group": "pr",
                 "revealProblems": "onProblem",
@@ -57,14 +47,14 @@
             }
         },
         {
-            "label": "Static type check",
+            "label": "Types",
             "type": "shell",
-            "command": "inv qtypes",
+            "command": "lefthook run types",
             "presentation": {
                 "group": "pr",
                 "clear": true,
                 "showReuseMessage": false,
             }
-        }
+        },
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -r gpu-requirements.t
 COPY requirements.txt .
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt --no-compile
 
+# Install lefthook (git hooks, e.g. pre-commit)
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | bash
+RUN apt install lefthook
+
 # Set the working directory to /app
 WORKDIR /app
 VOLUME psycop-common

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 cruft==2.15.0
 lumberman # Pull request management with graphite, written by MB
 invoke==2.1.0
+lefthook==0.1.2
 pre-commit==3.4.0
 pyright==1.1.332
 pytest-sugar==0.9.7

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,32 @@
+# EXAMPLE USAGE:
+#
+#   Refer for explanation to following link:
+#   https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md
+#
+# pre-push:
+#   commands:
+#     packages-audit:
+#       tags: frontend security
+#       run: yarn audit
+#     gems-audit:
+#       tags: backend security
+#       run: bundle audit
+#
+pre-commit:
+  commands:
+    format:
+      glob: "*.{py}"
+      run: inv lint
+      stage_fixed: true
+
+types:
+  commands:
+    pyright:
+      glob: "*.{py}"
+      run: pyright {push_files}
+
+test:
+  commands:
+    test:
+      glob: "*.{py}"
+      run: echo {staged_files} >/dev/null && inv test


### PR DESCRIPTION
Just want to show this tool off, and then we can discuss whether we want to add it.

Upside:
* Auto-stage changes on fix! Means we can lint on commit. No more manual pre-commit runs.

Main uncertainties:
* Can it run on Ovartaci?
    * No, it requires a download via either `brew`, `go` or `npm`
    * Users running linting should use `inv lint`
* How does it handle cases where the linter cannot fix it if `stage_fixed = True`? Should we run the linter twice to get errors?
    * It fails correctly

@HLasse, @KennethEnevoldsen, initial thoughts? Think we'll loop in the others if we don't outright reject it.

This would be a good time to migrate as much as possible out of pre-commit as well, i.e. removing black.