### PR TITLE
fix: baselinelogger should not default to None

### DIFF
--- a/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/baseline_preprocessing_pipeline/baseline_preprocessing_pipeline-20231115_120000.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/baseline_preprocessing_pipeline/baseline_preprocessing_pipeline-20231115_120000.cfg
@@ -1,5 +1,6 @@
 [preprocessing_pipeline]
 @preprocessing = "baseline_preprocessing_pipeline"
+logger = null
 
 [preprocessing_pipeline.*.age_filter]
 @preprocessing = "age_filter"

--- a/psycop/common/model_training_v2/config/historical_registry_configs/trainers/crossval_trainer/crossval_trainer-20231511-120000.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/trainers/crossval_trainer/crossval_trainer-20231511-120000.cfg
@@ -11,6 +11,7 @@ group_col_name = "dw_ek_borger"
 
 [trainer.preprocessing_pipeline]
 @preprocessing = "baseline_preprocessing_pipeline"
+logger = null
 
 [trainer.preprocessing_pipeline.*.age_filter]
 @preprocessing = "age_filter"

--- a/psycop/common/model_training_v2/config/historical_registry_configs/trainers/split_trainer/split_trainer-20231511-120000.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/trainers/split_trainer/split_trainer-20231511-120000.cfg
@@ -12,6 +12,7 @@ validation_outcome_col_name = "outcome"
 
 [trainer.preprocessing_pipeline]
 @preprocessing = "baseline_preprocessing_pipeline"
+logger = null
 
 [trainer.preprocessing_pipeline.*.age_filter]
 @preprocessing = "age_filter"

--- a/psycop/common/model_training_v2/hyperparameter_suggester/test_optuna_hyperparameter_search.cfg
+++ b/psycop/common/model_training_v2/hyperparameter_suggester/test_optuna_hyperparameter_search.cfg
@@ -1,6 +1,3 @@
-[logger]
-@loggers = "terminal_logger"
-
 [project_info]
 experiment_path = "/."
 
@@ -16,6 +13,7 @@ validation_data = {"@data":"minimal_test_data"}
 
 [trainer.preprocessing_pipeline]
 @preprocessing = "baseline_preprocessing_pipeline"
+logger = {"@loggers":"terminal_logger"}
 
 [trainer.preprocessing_pipeline.*.age_filter]
 @preprocessing = "age_filter"

--- a/psycop/common/model_training_v2/hyperparameter_suggester/test_optuna_hyperparameter_search.cfg
+++ b/psycop/common/model_training_v2/hyperparameter_suggester/test_optuna_hyperparameter_search.cfg
@@ -1,3 +1,6 @@
+[logger]
+@loggers = "terminal_logger"
+
 [project_info]
 experiment_path = "/."
 

--- a/psycop/common/model_training_v2/trainer/preprocessing/pipeline.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/pipeline.py
@@ -21,7 +21,7 @@ class PreprocessingPipeline(Protocol):
 
 @BaselineRegistry.preprocessing.register("baseline_preprocessing_pipeline")
 class BaselinePreprocessingPipeline(PreprocessingPipeline):
-    def __init__(self, *args: PresplitStep, logger: BaselineLogger | None = None) -> None:
+    def __init__(self, *args: PresplitStep, logger: BaselineLogger | None) -> None:
         self.steps = list(args)
         self.logger = logger
 


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
