### PR TITLE
ci: disable concurrency checks to avoid false cancellations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,6 @@ on:
 
 jobs:
   lint:
-    concurrency:
-      group: "${{ github.workflow }} @ ${{ github.ref }}"
-      cancel-in-progress: true
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/modified_shared_files.yml
+++ b/.github/workflows/modified_shared_files.yml
@@ -10,9 +10,6 @@ jobs:
   modified-library-files:
     permissions:
       pull-requests: write
-    concurrency:
-      group: "${{ github.workflow }} @ ${{ github.ref }}"
-      cancel-in-progress: true
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
