### PR TITLE
fix: ensure expectation counts are recast to int

### DIFF
--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_validator.py
@@ -99,7 +99,7 @@ class ColumnPrefixExpectation(PresplitStep):
             column for column in df.columns if column.startswith(expectation.prefix)
         ]
 
-        if len(matching_columns) != expectation.count:
+        if len(matching_columns) != int(expectation.count):
             return [
                 ColumnCountError(
                     f'{self._wrap_str_in_quotes(expectation.prefix)} matched {matching_columns if matching_columns else "None"}, expected {expectation.count}.'


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
