### PR TITLE
fix(#775): log outcome column as string, not Index

### DIFF
--- a/psycop/common/model_training_v2/trainer/cross_validator_trainer.py
+++ b/psycop/common/model_training_v2/trainer/cross_validator_trainer.py
@@ -33,7 +33,7 @@ class CrossValidatorTrainer(BaselineTrainer):
         y = pd.DataFrame(
             training_data_preprocessed[self.outcome_col_name], columns=[self.outcome_col_name]
         )
-        self.logger.info(f"\tOutcome: {y.columns}")
+        self.logger.info(f"\tOutcome: {list(y.columns)}")
 
         folds = StratifiedGroupKFold(n_splits=self.n_splits).split(
             X=X, y=y, groups=training_data_preprocessed[self.group_col_name]


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
