### PR TITLE
feat: unify naming classification model steps

### DIFF
--- a/psycop/common/model_training_v2/trainer/task/estimator_steps/lightgbm.py
+++ b/psycop/common/model_training_v2/trainer/task/estimator_steps/lightgbm.py
@@ -26,7 +26,7 @@ def lightgbm_classifier_step(
     reg_lambda: float = 0.0,
 ) -> ModelStep:
     return (
-        "lightgbm",
+        "classifier",
         LGBMClassifier(
             num_leaves=num_leaves,
             device_type=device_type,

--- a/psycop/common/model_training_v2/trainer/task/estimator_steps/logistic_regression.py
+++ b/psycop/common/model_training_v2/trainer/task/estimator_steps/logistic_regression.py
@@ -31,7 +31,7 @@ def logistic_regression_step(
     and is set to np.nan by default."""
 
     return (
-        "logistic_regression",
+        "classifier",
         LogisticRegression(
             penalty=penalty, solver=solver, C=C, l1_ratio=l1_ratio, random_state=41
         ),  # Random_state is required for reproducibility, e.g. getting the same result on every test

--- a/psycop/common/model_training_v2/trainer/task/estimator_steps/xgboost.py
+++ b/psycop/common/model_training_v2/trainer/task/estimator_steps/xgboost.py
@@ -30,7 +30,7 @@ def xgboost_classifier_step(
     The 'missing' hyperparameter specifies the value to be treated as missing and is set to np.nan by default.
     """
     return (
-        "xgboost",
+        "classifier",
         XGBClassifier(
             alpha=alpha,
             gamma=gamma,


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
This ensures that when we want to extract e.g. feature importance from the models, they will always be found under `pipeline.named_steps["classifier"]` instead of being the name of the model. Requires us to follow the naming convention when/if adding additional classification models, but no further downsides as I see it