### PR TITLE
Feat/843/when hyperparameter tuning add subfolder for each run

### DIFF
--- a/psycop/common/model_training_v2/config/baseline_pipeline.py
+++ b/psycop/common/model_training_v2/config/baseline_pipeline.py
@@ -20,7 +20,5 @@ def train_baseline_model(cfg_file: Path) -> float:
 
 def train_baseline_model_from_schema(cfg: BaselineSchema) -> float:
     result = cfg.trainer.train()
-    result.df.write_parquet(cfg.project_info.experiment_path / "eval_df.parquet")
-    # TODO: https://github.com/Aarhus-Psychiatry-Research/psycop-common/issues/447 Allow dynamic generation of experiments paths
 
     return result.metric.value

--- a/psycop/common/model_training_v2/config/baseline_schema.py
+++ b/psycop/common/model_training_v2/config/baseline_schema.py
@@ -1,18 +1,11 @@
-from pydantic import BaseModel, ConfigDict, DirectoryPath, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
-from psycop.common.global_utils.pydantic_basemodel import PSYCOPBaseModel
 from psycop.common.model_training_v2.loggers.base_logger import BaselineLogger
 from psycop.common.model_training_v2.trainer.base_trainer import BaselineTrainer
 
 
-class ProjectInfo(PSYCOPBaseModel):
-    experiment_path: DirectoryPath  # Experiment_path must be a directory which exists
-
-
 class BaselineSchema(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    project_info: ProjectInfo
     logger: BaselineLogger
     trainer: BaselineTrainer
 

--- a/psycop/common/model_training_v2/config/baseline_test_config.cfg
+++ b/psycop/common/model_training_v2/config/baseline_test_config.cfg
@@ -1,9 +1,6 @@
 [logger]
 @loggers = "terminal_logger"
 
-[project_info]
-experiment_path = "/."
-
 [trainer]
 @trainers = "split_trainer"
 uuid_col_name = "pred_time_uuid"

--- a/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/lightgbm/lightgbm_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/lightgbm/lightgbm_20240312_122432.cfg
@@ -1,9 +1,0 @@
-[placeholder]
-@estimator_steps = "lightgbm"
-num_leaves = 31
-max_bin = 63
-device_type = "cpu"
-n_estimators = 100
-learning_rate = 0.1
-reg_alpha = 0.0
-reg_lambda = 0.0

--- a/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/lightgbm/lightgbm_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/lightgbm/lightgbm_20240312_122432.cfg
@@ -1,0 +1,9 @@
+[placeholder]
+@estimator_steps = "lightgbm"
+num_leaves = 31
+max_bin = 63
+device_type = "cpu"
+n_estimators = 100
+learning_rate = 0.1
+reg_alpha = 0.0
+reg_lambda = 0.0

--- a/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/xgboost/xgboost_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/xgboost/xgboost_20240312_122432.cfg
@@ -1,9 +1,0 @@
-[placeholder]
-@estimator_steps = "xgboost"
-alpha = 0
-reg_lambda = 1
-max_depth = 3
-learning_rate = 0.3
-gamma = 0
-tree_method = "gpu_hist"
-n_estimators = 100

--- a/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/xgboost/xgboost_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps/xgboost/xgboost_20240312_122432.cfg
@@ -1,0 +1,9 @@
+[placeholder]
+@estimator_steps = "xgboost"
+alpha = 0
+reg_lambda = 1
+max_depth = 3
+learning_rate = 0.3
+gamma = 0
+tree_method = "gpu_hist"
+n_estimators = 100

--- a/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps_suggesters/lightgbm_suggester/lightgbm_suggester_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/estimator_steps_suggesters/lightgbm_suggester/lightgbm_suggester_20240312_122432.cfg
@@ -1,0 +1,7 @@
+[placeholder]
+@estimator_steps_suggesters = "lightgbm_suggester"
+num_leaves = [5,500,true]
+n_estimators = [5,500,true]
+learning_rate = [0.00001,0.2,true]
+reg_alpha = [0.0,0.2,false]
+reg_lambda = [0.0,0.2,false]

--- a/psycop/common/model_training_v2/config/historical_registry_configs/loggers/disk_logger/disk_logger_20231202_102416.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/loggers/disk_logger/disk_logger_20231202_102416.cfg
@@ -1,4 +1,4 @@
 
 [disk_logger]
 @loggers = "disk_logger"
-experiment_path = "tmp_path"
+run_path = "tmp_path"

--- a/psycop/common/model_training_v2/config/historical_registry_configs/suggesters/run_path_suggester/run_path_suggester_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/suggesters/run_path_suggester/run_path_suggester_20240312_122432.cfg
@@ -1,3 +1,3 @@
 [placeholder]
 @suggesters = "run_path_suggester"
-experiment_path = "str"
+experiment_path = "E:/shared_resources/project_path"

--- a/psycop/common/model_training_v2/config/historical_registry_configs/suggesters/run_path_suggester/run_path_suggester_20240312_122432.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/suggesters/run_path_suggester/run_path_suggester_20240312_122432.cfg
@@ -1,0 +1,3 @@
+[placeholder]
+@suggesters = "run_path_suggester"
+experiment_path = "str"

--- a/psycop/common/model_training_v2/config/populate_registry.py
+++ b/psycop/common/model_training_v2/config/populate_registry.py
@@ -47,6 +47,7 @@ def populate_baseline_registry() -> None:
     # Suggesters
     from ..hyperparameter_suggester.hyperparameter_suggester import SuggesterSpace
     from ..trainer.task.estimator_steps.logistic_regression import LogisticRegressionSuggester
+    from ..hyperparameter_suggester.suggesters.run_path_suggester import RunPathSuggester
 
     # Tasks
     from ..trainer.task.pipeline_constructor import pipeline_constructor

--- a/psycop/common/model_training_v2/hyperparameter_suggester/suggesters/run_path_suggester.py
+++ b/psycop/common/model_training_v2/hyperparameter_suggester/suggesters/run_path_suggester.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from optuna import Trial
+
+from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
+
+
+@BaselineRegistry.suggesters.register("run_path_suggester")
+class RunPathSuggester:
+    def __init__(self, experiment_path: str):
+        self.experiment_path = experiment_path
+
+    def suggest_hyperparameters(self, trial: Trial) -> str:
+        return str(Path(self.experiment_path) / f"run_{trial.number}")

--- a/psycop/common/model_training_v2/hyperparameter_suggester/test_optuna_hyperparameter_search.cfg
+++ b/psycop/common/model_training_v2/hyperparameter_suggester/test_optuna_hyperparameter_search.cfg
@@ -1,9 +1,6 @@
 [logger]
 @loggers = "terminal_logger"
 
-[project_info]
-experiment_path = "/."
-
 [trainer]
 @trainers = "split_trainer"
 uuid_col_name = "pred_time_uuid"

--- a/psycop/common/model_training_v2/loggers/disk_logger.py
+++ b/psycop/common/model_training_v2/loggers/disk_logger.py
@@ -12,10 +12,10 @@ from psycop.common.model_training_v2.trainer.task.base_metric import CalculatedM
 
 @BaselineRegistry.loggers.register("disk_logger")
 class DiskLogger(BaselineLogger):
-    def __init__(self, experiment_path: str) -> None:
-        self.experiment_path = Path(experiment_path)
-        self.log_path = self.experiment_path / "logs.log"
-        self.cfg_log_path = self.experiment_path / "config.cfg"
+    def __init__(self, run_path: str) -> None:
+        self.run_path = Path(run_path)
+        self.log_path = self.run_path / "logs.log"
+        self.cfg_log_path = self.run_path / "config.cfg"
 
         self._l = self._setup_logging_module()
 
@@ -58,7 +58,7 @@ class DiskLogger(BaselineLogger):
         return logger
 
     def log_artifact(self, local_path: Path) -> None:
-        shutil.copy(local_path, (self.experiment_path / local_path.name))
+        shutil.copy(local_path, (self.run_path / local_path.name))
 
     def log_dataset(self, dataframe: DataFrame, filename: str) -> None:
-        dataframe.write_parquet(self.experiment_path / filename)
+        dataframe.write_parquet(self.run_path / filename)

--- a/psycop/common/model_training_v2/loggers/test_disk_logger.py
+++ b/psycop/common/model_training_v2/loggers/test_disk_logger.py
@@ -6,7 +6,7 @@ from psycop.common.model_training_v2.loggers.disk_logger import DiskLogger
 
 
 def test_disklogger_text(tmpdir: str):
-    logger = DiskLogger(experiment_path=tmpdir)
+    logger = DiskLogger(run_path=tmpdir)
 
     message = "This is a test message"
     logger.info(message)
@@ -18,7 +18,7 @@ def test_disklogger_text(tmpdir: str):
 
 
 def test_disklogger_log_config(tmpdir: str):
-    logger = DiskLogger(experiment_path=tmpdir)
+    logger = DiskLogger(run_path=tmpdir)
 
     config = Config({"parameters": {"param1": 123, "param2": "abc"}})
     logger.log_config(config)
@@ -28,7 +28,7 @@ def test_disklogger_log_config(tmpdir: str):
 
 
 def test_disklogger_file(tmpdir: str):
-    logger = DiskLogger(experiment_path=f"{tmpdir}/logger_dir")
+    logger = DiskLogger(run_path=f"{tmpdir}/logger_dir")
 
     # Create the test file
     test_file = Path(tmpdir) / "test_file.txt"
@@ -39,4 +39,4 @@ def test_disklogger_file(tmpdir: str):
     logger.log_artifact(local_path=test_file)
 
     # Check that the test file exists at the artifact path
-    assert test_str in (logger.experiment_path / "test_file.txt").read_text()
+    assert test_str in (logger.run_path / "test_file.txt").read_text()

--- a/psycop/common/model_training_v2/test_pipeline.py
+++ b/psycop/common/model_training_v2/test_pipeline.py
@@ -5,7 +5,7 @@ from sklearn.pipeline import Pipeline
 from psycop.common.model_training_v2.config.baseline_pipeline import (
     train_baseline_model_from_schema,
 )
-from psycop.common.model_training_v2.config.baseline_schema import BaselineSchema, ProjectInfo
+from psycop.common.model_training_v2.config.baseline_schema import BaselineSchema
 from psycop.common.model_training_v2.config.config_utils import load_baseline_config
 from psycop.common.model_training_v2.loggers.terminal_logger import TerminalLogger
 from psycop.common.model_training_v2.trainer.cross_validator_trainer import CrossValidatorTrainer
@@ -30,11 +30,8 @@ from .loggers.multi_logger import MultiLogger
 from .trainer.task.estimator_steps.logistic_regression import logistic_regression_step
 
 
-def test_v2_train_model_pipeline(tmpdir: Path):
+def test_v2_train_model_pipeline():
     schema = BaselineSchema(
-        project_info=ProjectInfo(
-            experiment_path=Path(tmpdir)
-        ),  # Must recast to Path, since the tmpdir fixture returns a local(), not a Path(). This means it does not implement the .seek() method, which is required when we write the dataset to .parquet.
         logger=TerminalLogger(),
         trainer=SplitTrainer(
             uuid_col_name="pred_time_uuid",
@@ -57,19 +54,15 @@ def test_v2_train_model_pipeline(tmpdir: Path):
     assert train_baseline_model_from_schema(schema) == 1.0
 
 
-def test_v2_train_model_pipeline_from_cfg(tmpdir: Path):
+def test_v2_train_model_pipeline_from_cfg():
     config = load_baseline_config(Path(__file__).parent / "config" / "baseline_test_config.cfg")
-    config.project_info.model_config["frozen"] = False
-    config.project_info.experiment_path = Path(
-        tmpdir
-    )  # For some reason, the tmpdir fixture returns a local(), not a Path(). This means it does not implement the .seek() method, which is required when we write the dataset to .parquet.
+    config.model_config["frozen"] = False
 
     assert train_baseline_model_from_schema(config) == 1.0
 
 
 def test_v2_crossval_model_pipeline(tmp_path: Path):
     schema = BaselineSchema(
-        project_info=ProjectInfo(experiment_path=tmp_path),
         logger=MultiLogger(TerminalLogger(), DiskLogger(tmp_path.__str__())),
         trainer=CrossValidatorTrainer(
             uuid_col_name="pred_time_uuid",

--- a/psycop/projects/cvd/model_training/cvd_baseline.cfg
+++ b/psycop/projects/cvd/model_training/cvd_baseline.cfg
@@ -1,6 +1,3 @@
-[project_info]
-experiment_path = /.
-
 [logger]
 @loggers = "multi_logger"
 

--- a/psycop/projects/scz_bp/model_training/config/scz_bp_hparam.cfg
+++ b/psycop/projects/scz_bp/model_training/config/scz_bp_hparam.cfg
@@ -8,7 +8,7 @@
 [logger.*.disk_logger]
 @loggers = "disk_logger"
 
-[logger.*.disk_logger.experiment_path]
+[logger.*.disk_logger.run_path]
 @suggesters = "run_path_suggester"
 experiment_path = "E:/shared_resources/scz_bp/experiments/layers"
 

--- a/psycop/projects/scz_bp/model_training/config/scz_bp_hparam.cfg
+++ b/psycop/projects/scz_bp/model_training/config/scz_bp_hparam.cfg
@@ -1,5 +1,3 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/experiments/layers"
 
 [logger]
 @loggers = "multi_logger"
@@ -9,7 +7,10 @@ experiment_path = "E:/shared_resources/scz_bp/experiments/layers"
 
 [logger.*.disk_logger]
 @loggers = "disk_logger"
-experiment_path = ${project_info.experiment_path}
+
+[logger.*.disk_logger.experiment_path]
+@suggesters = "run_path_suggester"
+experiment_path = "E:/shared_resources/scz_bp/experiments/layers"
 
 [logger.*.mlflow_logger]
 @loggers = "mlflow_logger"

--- a/psycop/projects/scz_bp/model_training/config/scz_bp_structured_only.cfg
+++ b/psycop/projects/scz_bp/model_training/config/scz_bp_structured_only.cfg
@@ -1,15 +1,8 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/structured_only_hparam"
-
 [logger]
 @loggers = "multi_logger"
 
 [logger.*.terminal_logger]
 @loggers = "terminal_logger"
-
-[logger.*.disk_logger]
-@loggers = "disk_logger"
-experiment_path = ${project_info.experiment_path}
 
 [logger.*.mlflow_logger]
 @loggers = "mlflow_logger"

--- a/psycop/projects/scz_bp/model_training/config/scz_bp_structured_text.cfg
+++ b/psycop/projects/scz_bp/model_training/config/scz_bp_structured_text.cfg
@@ -1,15 +1,8 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/structured_text"
-
 [logger]
 @loggers = "multi_logger"
 
 [logger.*.terminal_logger]
 @loggers = "terminal_logger"
-
-[logger.*.disk_logger]
-@loggers = "disk_logger"
-experiment_path = ${project_info.experiment_path}
 
 [logger.*.mlflow_logger]
 @loggers = "mlflow_logger"

--- a/psycop/projects/scz_bp/model_training/config/scz_bp_text_only.cfg
+++ b/psycop/projects/scz_bp/model_training/config/scz_bp_text_only.cfg
@@ -1,15 +1,8 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/text_only"
-
 [logger]
 @loggers = "multi_logger"
 
 [logger.*.terminal_logger]
 @loggers = "terminal_logger"
-
-[logger.*.disk_logger]
-@loggers = "disk_logger"
-experiment_path = ${project_info.experiment_path}
 
 [logger.*.mlflow_logger]
 @loggers = "mlflow_logger"

--- a/psycop/projects/scz_bp/text_experiment/text_exp_combined_tfidf_encoder_config.cfg
+++ b/psycop/projects/scz_bp/text_experiment/text_exp_combined_tfidf_encoder_config.cfg
@@ -1,6 +1,3 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/text_exp"
-
 [logger]
 @loggers = "multi_logger"
 

--- a/psycop/projects/scz_bp/text_experiment/text_exp_config.cfg
+++ b/psycop/projects/scz_bp/text_experiment/text_exp_config.cfg
@@ -1,6 +1,3 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/text_exp_5_y"
-
 [logger]
 @loggers = "multi_logger"
 

--- a/psycop/projects/scz_bp/text_experiment/text_exp_keywords.cfg
+++ b/psycop/projects/scz_bp/text_experiment/text_exp_keywords.cfg
@@ -1,6 +1,3 @@
-[project_info]
-experiment_path = "E:/shared_resources/scz_bp/text_exp"
-
 [logger]
 @loggers = "multi_logger"
 

--- a/psycop/projects/t2d/feature_generation/lookbehind_experiment/lookbehind_config.cfg
+++ b/psycop/projects/t2d/feature_generation/lookbehind_experiment/lookbehind_config.cfg
@@ -1,6 +1,3 @@
-[project_info]
-experiment_path = "E:/shared_resources/t2d_lookbehind_experiment"
-
 [logger]
 @loggers = "multi_logger"
 


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
Removes the `project_info` (aka `experiment_path`) from the schema (`psycop/common/model_training_v2/config/baseline_schema.py`). `experiment_path` was only used to save the eval_df to disk _after_ training (outside of the trainer) - a functionality which has been delegated to the loggers.  

Instead, loggers are now the only ones to handle saving files to disk. If one wants to save to disk to a unique location for each trial, this can be done using the `run_path_suggester` which creates a unique run name to instantiate `DiskLogger` with (see example below). Saving to eval_dfs to Mlflow has been approved and added in #864 

I've updated all v2 configs so no errors should occur 👍

```
[logger.*.disk_logger]
@loggers = "disk_logger"

[logger.*.disk_logger.run_path]
@suggesters = "run_path_suggester"
experiment_path = "E:/shared_resources/scz_bp/a_clever_experiment"
```