### PR TITLE
build(deps): add glances

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pyright==1.1.332
 pytest-sugar==0.9.7
 ruff==0.1.14
 pandas-stubs==2.1.1.230928
+glances==3.4.0.5


### PR DESCRIPTION
A htop-like tool that also works on Windows.

On Ovartaci, I had to manually create a file for it to run. Seems we might not have write-permissions for sub-directories of `\Local\Temp`:

```python
from pathlib import Path

if __name__ == "__main__":
    user = "adminmanber"
    dir = Path(f"C:/Users/{user}/AppData/Local/Temp/glances-onerm/")
    dir.mkdir(exist_ok=True)
   (dir / f"{user}.log").write_text("")
```

@HLasse You might find this interesting! If it passes security-checks, it could make it much easier to check if others are running something before starting one's own job.