### PR TITLE
refactor: ensure logging when training from mutated cfg

### DIFF
--- a/psycop/common/model_training_v2/config/baseline_pipeline.py
+++ b/psycop/common/model_training_v2/config/baseline_pipeline.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import confection
 from confection import Config
 
 from psycop.common.model_training_v2.config.baseline_registry import BaselineRegistry
@@ -7,7 +8,13 @@ from psycop.common.model_training_v2.config.baseline_schema import BaselineSchem
 
 
 def train_baseline_model(cfg_file: Path) -> float:
+    """When you just want to use a file."""
     cfg = Config().from_disk(cfg_file)
+    return train_baseline_model_from_cfg(cfg)
+
+
+def train_baseline_model_from_cfg(cfg: confection.Config) -> float:
+    """When you want to programatically change options before training, while logging the cfg."""
     cfg_schema = BaselineSchema(**BaselineRegistry.resolve(cfg))
     cfg_schema.logger.log_config(cfg)
     cfg_schema.logger.warn(
@@ -19,6 +26,7 @@ def train_baseline_model(cfg_file: Path) -> float:
 
 
 def train_baseline_model_from_schema(cfg: BaselineSchema) -> float:
+    """For just training"""
     result = cfg.trainer.train()
 
     return result.metric.value


### PR DESCRIPTION
@HLasse Post-merge review. When programatically changing configs, recommend we use `train_baseline_model_from_cfg`. Was the cause of my confusion in #907.