### PR TITLE
fix: `QuarantineFilter` does not remove prediction times on same day

### DIFF
--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/row_filter_other.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/row_filter_other.py
@@ -103,14 +103,14 @@ class QuarantineFilter(PresplitStep):
 
         time_since_quarantine = df_with_quarantine_timestamps.with_columns(
             (pl.col(self.timestamp_col_name) - pl.col("timestamp_quarantine"))
-            .dt.days()
-            .alias("days_since_quarantine")
+            .dt.seconds()
+            .alias("seconds_since_quarantine")
         )
 
         # Check if the quarantine date hits the prediction time
         hit_by_quarantine = time_since_quarantine.filter(
-            (pl.col("days_since_quarantine") < self.quarantine_interval_days)
-            & (pl.col("days_since_quarantine") > 0)
+            (pl.col("seconds_since_quarantine") < self.quarantine_interval_days * 60 * 60 * 24)
+            & (pl.col("seconds_since_quarantine") > 0)
         ).select(self._tmp_pred_time_uuid_col_name)
 
         # Use these rows to filter the prediction times, ensuring that all columns are kept

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/test_row_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/test_row_filters.py
@@ -83,6 +83,7 @@ def test_filter_by_quarantine_period():
         1,2020-12-01 00:00:01, # keep: before quarantine date
         1,2022-12-01 00:00:01, # drop: within quarantine days from the first quarantine date
         1,2026-02-01 00:00:01, # keep: outside quarantine days from the first quarantine date
+        1,2021-01-01 00:01:00  # drop: same day, later time
         2,2023-02-01 00:00:01, # keep: no quarantine date for this id
         """
     ).lazy()


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
Fixes #1008 

Note @bokajgd @erikperfalk @sarakolding if you have used `QuarantineFilter` to remove e.g. incident cases in the last X years, if the outcome happened on the same day as a prediction time they were not filtered. Probably not major (in my case, approximately 200 prediction times that should have been removed)