### PR TITLE
fix: year parsing in temporal view

### DIFF
--- a/psycop/projects/forced_admission_inpatient/model_eval/temporal_view.py
+++ b/psycop/projects/forced_admission_inpatient/model_eval/temporal_view.py
@@ -25,7 +25,7 @@ class TemporalStabilityPlot(SingleRunPlot):
         df = pl.concat(run.to_dataframe() for run in self.data)
 
         df = df.with_columns(
-            pl.col("train_end_date").dt.iso_year().cast(pl.Utf8).alias("train_end_year"),
+            pl.col("train_end_date").dt.year().cast(pl.Utf8).alias("train_end_year"),
             (pl.col("start_date") - (pl.col("train_end_date"))).alias("since_train_end"),
         )
 


### PR DESCRIPTION
<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
@bokajgd I copy pasted the code and found a bug in the date parsing - this fixes it ;)