### PR TITLE
fix: lookbehind combination col filter

### DIFF
--- a/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/lookbehind_combination_col_filter/lookbehind_combination_col_filter-20231115-120000.cfg
+++ b/psycop/common/model_training_v2/config/historical_registry_configs/preprocessing/lookbehind_combination_col_filter/lookbehind_combination_col_filter-20231115-120000.cfg
@@ -1,4 +1,4 @@
 [placeholder]
 @preprocessing = "lookbehind_combination_col_filter"
-lookbehinds = [1,2]
+lookbehinds = "1,2"
 pred_col_prefix = "pred_"

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_filters.py
@@ -11,7 +11,9 @@ from psycop.common.model_training_v2.trainer.preprocessing.step import PresplitS
 @BaselineRegistry.preprocessing.register("lookbehind_combination_col_filter")
 class LookbehindCombinationColFilter(PresplitStep):
     def __init__(self, lookbehinds: str, pred_col_prefix: str):
-        self.lookbehinds = {f"within_{lookbehind}_days" for lookbehind in ast.literal_eval(lookbehinds)}
+        self.lookbehinds = {
+            f"within_{lookbehind}_days" for lookbehind in ast.literal_eval(lookbehinds)
+        }
         self.pred_col_prefix = pred_col_prefix
         self.lookbehind_pattern = r"(within_\d+_days)"
 

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/column_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/column_filters.py
@@ -1,3 +1,4 @@
+import ast
 import re
 
 import polars as pl
@@ -9,10 +10,10 @@ from psycop.common.model_training_v2.trainer.preprocessing.step import PresplitS
 
 @BaselineRegistry.preprocessing.register("lookbehind_combination_col_filter")
 class LookbehindCombinationColFilter(PresplitStep):
-    def __init__(self, lookbehinds: set[int], pred_col_prefix: str):
-        self.lookbehinds = lookbehinds
+    def __init__(self, lookbehinds: str, pred_col_prefix: str):
+        self.lookbehinds = {f"within_{lookbehind}_days" for lookbehind in ast.literal_eval(lookbehinds)}
         self.pred_col_prefix = pred_col_prefix
-        self.lookbehind_pattern = r"within_(\d+)_days"
+        self.lookbehind_pattern = r"(within_\d+_days)"
 
     def apply(self, input_df: pl.LazyFrame) -> pl.LazyFrame:
         pred_cols_with_lookbehind = [
@@ -22,7 +23,7 @@ class LookbehindCombinationColFilter(PresplitStep):
         ]
 
         lookbehinds_in_dataset = {
-            int(re.findall(pattern=self.lookbehind_pattern, string=col)[0])
+            re.findall(pattern=self.lookbehind_pattern, string=col)[0]
             for col in pred_cols_with_lookbehind
         }
 
@@ -51,7 +52,7 @@ class LookbehindCombinationColFilter(PresplitStep):
         return input_df.drop(cols_to_drop)
 
     def _cols_with_lookbehind_not_in_lookbehinds(
-        self, pred_cols_with_lookbehind: list[str], lookbehinds_to_keep: set[int]
+        self, pred_cols_with_lookbehind: list[str], lookbehinds_to_keep: set[str]
     ) -> list[str]:
         """Identify columns that have a lookbehind that is not in lookbehinds_to_keep."""
         return [

--- a/psycop/common/model_training_v2/trainer/preprocessing/steps/test_column_filters.py
+++ b/psycop/common/model_training_v2/trainer/preprocessing/steps/test_column_filters.py
@@ -18,7 +18,7 @@ def test_lookbehind_combination_filter():
 
     from psycop.common.model_training_v2.loggers.terminal_logger import TerminalLogger
 
-    lookbehind_filter = LookbehindCombinationColFilter(lookbehinds={2, 3}, pred_col_prefix="pred_")
+    lookbehind_filter = LookbehindCombinationColFilter(lookbehinds="2, 3", pred_col_prefix="pred_")
     lookbehind_filter.set_logger(TerminalLogger())
 
     result = lookbehind_filter.apply(df)


### PR DESCRIPTION
when selecting a combination of lookbehinds, we were selecting only based on integers - meaning if you were trying to select predictors with lookbehinds of 1, you would not only get within_1_days, but also within_10_days or even f1_disorders
