### PR TITLE
fix: only require code reviews when changes are made in root files or common scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# File specifying which folders require reviews when merging changes to main
+
+# Root file
+/*  @yAarhus-Psychiatry-Research/devs
+
+# Common folders
+/psycop/common/     @your-org/devs


### PR DESCRIPTION
Only require code reviews when changes are made in root files or common scripts