### PR TITLE
fix: cap cache size to re-enable dev container build for actions

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -28,9 +28,6 @@ jobs:
           mkdir -p ~/.config/gh
           touch ~/.config/gh/hosts.yml
 
-      - name: Clear buildx cache # Pruning cache to ensure the dev container build does not reach size limits
-        run: docker buildx prune -af
-
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,16 +30,16 @@ RUN npm install -g snyk
 RUN pip install uv
 
 COPY test-requirements.txt .
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install -r test-requirements.txt --no-compile
+RUN uv pip install --no-cache-dir -r test-requirements.txt --no-compile
 
 COPY dev-requirements.txt .
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install -r dev-requirements.txt --no-compile
+RUN uv pip install --no-cache-dir -r dev-requirements.txt --no-compile
 
 COPY gpu-requirements.txt .
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install -r gpu-requirements.txt --no-compile
+RUN uv pip install --no-cache-dir -r gpu-requirements.txt --no-compile
 
 COPY requirements.txt .
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install -r requirements.txt --no-compile
+RUN uv pip install --no-cache-dir -r requirements.txt --no-compile
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
Currently, dev container build for github actions fills up the cache. 
Adds capping to cache size in Dockerfile.