### PR TITLE
Change vulnerability scan schedule to 06:00 on Mondays

### DIFF
--- a/.github/workflows/periodical_vulnerability_scan.yml
+++ b/.github/workflows/periodical_vulnerability_scan.yml
@@ -4,7 +4,7 @@ name: periodical_vulnerability_scan
 
 on:
   schedule: # 1 for Monday, 2 for Tuesday, etc.
-    - cron: "0 09 * * 1"
+    - cron: "0 06 * * 1"
   workflow_dispatch: # run manually
 
 jobs:


### PR DESCRIPTION
it was set to 9 but didn't run until 14 (must be on a different time zone)

<!--
Reviews go much faster if the reviewer knows what to focus on! Help them out, e.g.:
Reviewers can skip X, but should pay attention to Y.
-->
